### PR TITLE
refactor(chat): rename llm variable to cm (chatModel) for better naming consistency

### DIFF
--- a/quickstart/chat/generate.go
+++ b/quickstart/chat/generate.go
@@ -24,18 +24,18 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
-func generate(ctx context.Context, llm model.ToolCallingChatModel, in []*schema.Message) *schema.Message {
-	result, err := llm.Generate(ctx, in)
+func generate(ctx context.Context, cm model.ToolCallingChatModel, in []*schema.Message) *schema.Message {
+	result, err := cm.Generate(ctx, in)
 	if err != nil {
-		log.Fatalf("llm generate failed: %v", err)
+		log.Fatalf("chatModel generate failed: %v", err)
 	}
 	return result
 }
 
-func stream(ctx context.Context, llm model.ToolCallingChatModel, in []*schema.Message) *schema.StreamReader[*schema.Message] {
-	result, err := llm.Stream(ctx, in)
+func stream(ctx context.Context, cm model.ToolCallingChatModel, in []*schema.Message) *schema.StreamReader[*schema.Message] {
+	result, err := cm.Stream(ctx, in)
 	if err != nil {
-		log.Fatalf("llm generate failed: %v", err)
+		log.Fatalf("chatModel generate failed: %v", err)
 	}
 	return result
 }

--- a/quickstart/chat/main.go
+++ b/quickstart/chat/main.go
@@ -29,17 +29,17 @@ func main() {
 	messages := createMessagesFromTemplate()
 	log.Printf("messages: %+v\n\n", messages)
 
-	// 创建llm
-	log.Printf("===create llm===\n")
-	cm := createOpenAIChatModel(ctx)
-	// cm := createOllamaChatModel(ctx)
-	log.Printf("create llm success\n\n")
+	// 创建chatModel
+	log.Printf("===create chatModel===\n")
+	// cm := createOpenAIChatModel(ctx)
+	cm := createOllamaChatModel(ctx)
+	log.Printf("create chatModel success\n\n")
 
-	log.Printf("===llm generate===\n")
+	log.Printf("===chatModel generate===\n")
 	result := generate(ctx, cm, messages)
 	log.Printf("result: %+v\n\n", result)
 
-	log.Printf("===llm stream generate===\n")
+	log.Printf("===chatModel stream generate===\n")
 	streamResult := stream(ctx, cm, messages)
 	reportStream(streamResult)
 }


### PR DESCRIPTION
rename llm to cm (chatModel) in chat examples for improved readability