### PR TITLE
feat(chatmodel): printing actual request and response

### DIFF
--- a/components/model/httptransport/curlrt.go
+++ b/components/model/httptransport/curlrt.go
@@ -249,11 +249,11 @@ func newLoggingReadCloser(rc io.ReadCloser, ctx context.Context, c *CurlRT) io.R
 	if c.ctxLogger == nil {
 		buf = &bytes.Buffer{}
 	}
-	cap := c.maxStreamLogBytes
-	if cap <= 0 {
-		cap = 8192
+	ca := c.maxStreamLogBytes
+	if ca <= 0 {
+		ca = 8192
 	}
-	return &loggingReadCloser{rc: rc, ctx: ctx, l: c.logger, cl: c.ctxLogger, cap: cap, summary: buf}
+	return &loggingReadCloser{rc: rc, ctx: ctx, l: c.logger, cl: c.ctxLogger, cap: ca, summary: buf}
 }
 
 func (lrc *loggingReadCloser) Read(p []byte) (int, error) {

--- a/components/model/httptransport/example/invoke/main.go
+++ b/components/model/httptransport/example/invoke/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cloudwego/eino-ext/components/model/openai"
 	"github.com/cloudwego/eino/schema"
 
-	httptransport "github.com/cloudwego/eino-examples/components/model/httptransport"
+	"github.com/cloudwego/eino-examples/components/model/httptransport"
 )
 
 func main() {

--- a/components/model/httptransport/example/stream/main.go
+++ b/components/model/httptransport/example/stream/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cloudwego/eino-ext/components/model/openai"
 	"github.com/cloudwego/eino/schema"
 
-	httptransport "github.com/cloudwego/eino-examples/components/model/httptransport"
+	"github.com/cloudwego/eino-examples/components/model/httptransport"
 )
 
 func main() {


### PR DESCRIPTION
add an example demonstrating how to log the actual request to and response from LLM. Including both Generate and Stream support.