### PR TITLE
feat(adk): add input msg log to supervisor example

### DIFF
--- a/adk/multiagent/supervisor/supervisor.go
+++ b/adk/multiagent/supervisor/supervisor.go
@@ -23,13 +23,17 @@ import (
 	"time"
 
 	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/callbacks"
 
+	"github.com/cloudwego/eino-examples/adk/common/model"
 	"github.com/cloudwego/eino-examples/adk/common/prints"
 	"github.com/cloudwego/eino-examples/adk/common/trace"
 )
 
 func main() {
 	ctx := context.Background()
+
+	callbacks.AppendGlobalHandlers(model.GetInputLoggerCallback())
 
 	traceCloseFn, startSpanFn := trace.AppendCozeLoopCallbackIfConfigured(ctx)
 	defer traceCloseFn(ctx)


### PR DESCRIPTION
show exactly what messages act as input before each `ChatModel` call