### PR TITLE
feat(chatwitheino): replace adk.Runner with TurnLoop for abort and preempt support

### DIFF
--- a/quickstart/chatwitheino/a2ui/streamer.go
+++ b/quickstart/chatwitheino/a2ui/streamer.go
@@ -44,9 +44,11 @@ func RenderHistory(w io.Writer, sessionID string, history []*schema.Message) err
 }
 
 // StreamToWriter converts an agent event stream into A2UI JSONL messages written to w.
-// It returns the content of the last assistant text response, the interrupt ID if the
-// agent was paused awaiting human approval (non-empty), the final A2UI msgIdx, and any error.
-func StreamToWriter(w io.Writer, sessionID string, history []*schema.Message, events *adk.AsyncIterator[*adk.AgentEvent]) (string, string, int, error) {
+// It returns the content of the last assistant text response, all intermediate messages
+// (assistant tool-call messages and tool results) for session persistence,
+// the interrupt ID if the agent was paused awaiting human approval (non-empty),
+// the final A2UI msgIdx, and any error.
+func StreamToWriter(w io.Writer, sessionID string, history []*schema.Message, events *adk.AsyncIterator[*adk.AgentEvent]) (string, []*schema.Message, string, int, error) {
 	surfaceID := "chat-" + sessionID
 
 	rootChildren := make([]string, 0, len(history))
@@ -57,15 +59,15 @@ func StreamToWriter(w io.Writer, sessionID string, history []*schema.Message, ev
 	if err := emit(w, Message{
 		BeginRendering: &BeginRenderingMsg{SurfaceID: surfaceID, Root: "root-col"},
 	}); err != nil {
-		return "", "", 0, err
+		return "", nil, "", 0, err
 	}
 	if err := emitHistory(w, surfaceID, history, rootChildren); err != nil {
-		return "", "", 0, err
+		return "", nil, "", 0, err
 	}
 
 	msgIdx := len(history)
-	lastContent, interruptID, err := streamEvents(w, surfaceID, &rootChildren, &msgIdx, events)
-	return lastContent, interruptID, msgIdx, err
+	lastContent, intermediates, interruptID, err := streamEvents(w, surfaceID, &rootChildren, &msgIdx, events)
+	return lastContent, intermediates, interruptID, msgIdx, err
 }
 
 // StreamContinue resumes an interrupted stream without resetting the client UI.
@@ -80,14 +82,23 @@ func StreamContinue(w io.Writer, sessionID string, startMsgIdx int, events *adk.
 	}
 
 	msgIdx := startMsgIdx
-	lastContent, interruptID, err := streamEvents(w, surfaceID, &rootChildren, &msgIdx, events)
+	lastContent, _, interruptID, err := streamEvents(w, surfaceID, &rootChildren, &msgIdx, events)
 	return lastContent, interruptID, msgIdx, err
 }
 
 // streamEvents is the shared event-processing loop used by StreamToWriter and StreamContinue.
-func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx *int, events *adk.AsyncIterator[*adk.AgentEvent]) (string, string, error) {
+// Returns: last assistant text content, intermediate messages (tool calls + tool results),
+// interrupt ID (if any), and error.
+func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx *int, events *adk.AsyncIterator[*adk.AgentEvent]) (string, []*schema.Message, string, error) {
 	var lastContent strings.Builder
 	var interruptID string
+	var intermediates []*schema.Message
+
+	// writerBroken is set when SSE writes fail (e.g. browser aborted the
+	// fetch during a preempt). When true we stop writing to the UI but keep
+	// consuming events so that intermediates are fully accumulated for
+	// session persistence.
+	writerBroken := false
 
 	for {
 		event, ok := events.Next()
@@ -98,8 +109,10 @@ func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx 
 
 		if event.Err != nil {
 			log.Printf("[a2ui] event error: %v", event.Err)
-			_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "error", event.Err.Error())
-			return lastContent.String(), "", event.Err
+			if !writerBroken {
+				_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "error", event.Err.Error())
+			}
+			return lastContent.String(), intermediates, "", event.Err
 		}
 
 		// Detect interrupt: the agent is paused awaiting human input.
@@ -118,13 +131,15 @@ func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx 
 				desc = fmt.Sprintf("%v", ictxs[0].Info)
 			}
 			log.Printf("[a2ui] interrupt: id=%s desc=%q", interruptID, desc)
-			_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "approval needed", desc)
-			_ = emit(w, Message{
-				InterruptRequest: &InterruptRequestMsg{
-					InterruptID: interruptID,
-					Description: desc,
-				},
-			})
+			if !writerBroken {
+				_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "approval needed", desc)
+				_ = emit(w, Message{
+					InterruptRequest: &InterruptRequestMsg{
+						InterruptID: interruptID,
+						Description: desc,
+					},
+				})
+			}
 			break
 		}
 
@@ -151,9 +166,13 @@ func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx 
 		switch role {
 		case schema.Tool:
 			// Drain the stream if needed, then show a compact tool-result chip.
-			content := drainToolResult(mo)
+			content, toolCallID := drainToolResult(mo)
 			log.Printf("[a2ui] tool result (%d chars): %.200s", len(content), content)
-			_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "tool result", content)
+			if !writerBroken {
+				_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "tool result", content)
+			}
+			// Persist tool result for history (ToolCallID is required by the LLM API).
+			intermediates = append(intermediates, &schema.Message{Role: schema.Tool, Content: content, ToolCallID: toolCallID})
 
 		default:
 			// Assistant (or unknown role) — may carry text content and/or tool calls.
@@ -170,6 +189,7 @@ func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx 
 				dataKey := fmt.Sprintf("%s/msg-%d", surfaceID, textIdx)
 
 				nameByIdx := map[int]string{}
+				idByIdx := map[int]string{}
 				argsByIdx := map[int]*strings.Builder{}
 				var tcOrder []int
 				seenTCIdx := map[int]bool{}
@@ -200,6 +220,9 @@ func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx 
 						if tc.Function.Name != "" && nameByIdx[idx] == "" {
 							nameByIdx[idx] = tc.Function.Name
 						}
+						if tc.ID != "" && idByIdx[idx] == "" {
+							idByIdx[idx] = tc.ID
+						}
 						if tc.Function.Arguments != "" {
 							if argsByIdx[idx] == nil {
 								argsByIdx[idx] = &strings.Builder{}
@@ -209,25 +232,35 @@ func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx 
 					}
 
 					// Emit text tokens to the UI immediately.
-					if chunk.Content != "" {
+					if chunk.Content != "" && !writerBroken {
 						if !shellEmitted {
 							// Commit this message slot and send the card scaffold with a data binding.
 							*rootChildren = append(*rootChildren, cardID)
 							*msgIdx++
 							if shellErr := emitMessageShell(w, surfaceID, *rootChildren, cardID, colID, roleID, contentID, dataKey, roleToLabel(role)); shellErr != nil {
-								return lastContent.String(), "", shellErr
+								log.Printf("[a2ui] SSE writer broken, continuing for persistence: %v", shellErr)
+								writerBroken = true
+							} else {
+								shellEmitted = true
 							}
-							shellEmitted = true
 						}
+						if !writerBroken {
+							accContent.WriteString(chunk.Content)
+							if dataErr := emitDataUpdate(w, surfaceID, dataKey, accContent.String()); dataErr != nil {
+								log.Printf("[a2ui] SSE writer broken, continuing for persistence: %v", dataErr)
+								writerBroken = true
+							}
+						}
+					}
+					// Always accumulate content for persistence, even when writer is broken.
+					if chunk.Content != "" && writerBroken {
 						accContent.WriteString(chunk.Content)
-						if dataErr := emitDataUpdate(w, surfaceID, dataKey, accContent.String()); dataErr != nil {
-							return lastContent.String(), "", dataErr
-						}
 					}
 				}
 
 				// Build final tool-call list and emit chips.
 				var toolCalls []toolCallInfo
+				var schemaToolCalls []schema.ToolCall
 				for _, i := range tcOrder {
 					name := nameByIdx[i]
 					if name == "" {
@@ -238,35 +271,54 @@ func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx 
 						args = ab.String()
 					}
 					toolCalls = append(toolCalls, toolCallInfo{Name: name, Args: args})
+					schemaToolCalls = append(schemaToolCalls, schema.ToolCall{
+						ID:       idByIdx[i],
+						Function: schema.FunctionCall{Name: name, Arguments: args},
+					})
 				}
 				log.Printf("[a2ui] assistant stream: content=%d chars toolCalls=%d", accContent.Len(), len(toolCalls))
 
-				for _, tc := range toolCalls {
-					log.Printf("[a2ui] tool call: %s args=%s", tc.Name, tc.Args)
-					_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "tool call", formatToolCall(tc))
+				if !writerBroken {
+					for _, tc := range toolCalls {
+						log.Printf("[a2ui] tool call: %s args=%s", tc.Name, tc.Args)
+						_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "tool call", formatToolCall(tc))
+					}
 				}
-				if shellEmitted {
+				if shellEmitted || accContent.Len() > 0 {
 					lastContent.Reset()
 					lastContent.WriteString(accContent.String())
+				}
+				// Persist assistant message with tool calls for history.
+				if shellEmitted || accContent.Len() > 0 || len(schemaToolCalls) > 0 {
+					intermediates = append(intermediates, schema.AssistantMessage(accContent.String(), schemaToolCalls))
 				}
 
 			} else if mo.Message != nil {
 				msg := mo.Message
 				log.Printf("[a2ui] assistant message: content=%d chars toolCalls=%d", len(msg.Content), len(msg.ToolCalls))
 
-				for _, tc := range msg.ToolCalls {
-					log.Printf("[a2ui] tool call: %s args=%s", tc.Function.Name, tc.Function.Arguments)
-					_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "tool call", formatToolCall(toolCallInfo{
-						Name: tc.Function.Name,
-						Args: tc.Function.Arguments,
-					}))
+				if !writerBroken {
+					for _, tc := range msg.ToolCalls {
+						log.Printf("[a2ui] tool call: %s args=%s", tc.Function.Name, tc.Function.Arguments)
+						_ = emitToolChip(w, surfaceID, rootChildren, msgIdx, "tool call", formatToolCall(toolCallInfo{
+							Name: tc.Function.Name,
+							Args: tc.Function.Arguments,
+						}))
+					}
+					if msg.Content != "" {
+						if err := emitTextCard(w, surfaceID, rootChildren, msgIdx, roleToLabel(role), msg.Content); err != nil {
+							log.Printf("[a2ui] SSE writer broken, continuing for persistence: %v", err)
+							writerBroken = true
+						}
+					}
 				}
 				if msg.Content != "" {
-					if err := emitTextCard(w, surfaceID, rootChildren, msgIdx, roleToLabel(role), msg.Content); err != nil {
-						return lastContent.String(), "", err
-					}
 					lastContent.Reset()
 					lastContent.WriteString(msg.Content)
+				}
+				// Persist assistant message for history.
+				if msg.Content != "" || len(msg.ToolCalls) > 0 {
+					intermediates = append(intermediates, schema.AssistantMessage(msg.Content, msg.ToolCalls))
 				}
 			} else {
 				log.Printf("[a2ui] assistant event with no stream and no message (skipped)")
@@ -279,7 +331,7 @@ func streamEvents(w io.Writer, surfaceID string, rootChildren *[]string, msgIdx 
 		}
 	}
 
-	return lastContent.String(), interruptID, nil
+	return lastContent.String(), intermediates, interruptID, nil
 }
 
 // toolCallInfo holds the accumulated name and arguments for one tool call.
@@ -290,7 +342,7 @@ type toolCallInfo struct {
 
 // consumeStream reads all chunks from a MessageStream, accumulating text content
 // and tool call info. Used for tool-result messages that may arrive as streams.
-func consumeStream(stream *schema.StreamReader[*schema.Message]) (content string, toolCalls []toolCallInfo) {
+func consumeStream(stream *schema.StreamReader[*schema.Message]) (content string, toolCalls []toolCallInfo, toolCallID string) {
 	nameByIdx := map[int]string{}
 	argsByIdx := map[int]*strings.Builder{}
 	var order []int
@@ -308,6 +360,9 @@ func consumeStream(stream *schema.StreamReader[*schema.Message]) (content string
 		}
 		if chunk.Content != "" {
 			buf.WriteString(chunk.Content)
+		}
+		if chunk.ToolCallID != "" && toolCallID == "" {
+			toolCallID = chunk.ToolCallID
 		}
 		for _, tc := range chunk.ToolCalls {
 			idx := 0
@@ -341,19 +396,19 @@ func consumeStream(stream *schema.StreamReader[*schema.Message]) (content string
 		}
 		toolCalls = append(toolCalls, toolCallInfo{Name: name, Args: args})
 	}
-	return buf.String(), toolCalls
+	return buf.String(), toolCalls, toolCallID
 }
 
-// drainToolResult reads content from a tool-result MessageVariant.
-func drainToolResult(mo *adk.MessageVariant) string {
+// drainToolResult reads content and ToolCallID from a tool-result MessageVariant.
+func drainToolResult(mo *adk.MessageVariant) (string, string) {
 	if mo.IsStreaming && mo.MessageStream != nil {
-		content, _ := consumeStream(mo.MessageStream)
-		return content
+		content, _, toolCallID := consumeStream(mo.MessageStream)
+		return content, toolCallID
 	}
 	if mo.Message != nil {
-		return mo.Message.Content
+		return mo.Message.Content, mo.Message.ToolCallID
 	}
-	return ""
+	return "", ""
 }
 
 // formatToolCall formats a toolCallInfo for display in a chip.
@@ -431,11 +486,27 @@ func emitHistory(w io.Writer, surfaceID string, history []*schema.Message, rootC
 		colID := fmt.Sprintf("msg-%d-col", i)
 		roleID := fmt.Sprintf("msg-%d-role", i)
 		contentID := fmt.Sprintf("msg-%d-content", i)
+
+		// Determine the display label and body text.
+		// Assistant messages with tool calls but no text are shown as "tool call" chips.
+		// Tool-role messages are shown as "tool result" chips.
+		label := roleToLabel(msg.Role)
+		body := msg.Content
+		if msg.Role == schema.Assistant && len(msg.ToolCalls) > 0 && msg.Content == "" {
+			label = "tool call"
+			body = formatToolCall(toolCallInfo{
+				Name: msg.ToolCalls[0].Function.Name,
+				Args: msg.ToolCalls[0].Function.Arguments,
+			})
+		} else if msg.Role == schema.Tool {
+			label = "tool result"
+		}
+
 		comps = append(comps,
 			Component{ID: cardID, Component: ComponentValue{Card: &CardComp{Children: []string{colID}}}},
 			Component{ID: colID, Component: ComponentValue{Column: &ColumnComp{Children: []string{roleID, contentID}}}},
-			Component{ID: roleID, Component: ComponentValue{Text: &TextComp{Value: roleToLabel(msg.Role), UsageHint: "caption"}}},
-			Component{ID: contentID, Component: ComponentValue{Text: &TextComp{Value: msg.Content, UsageHint: "body"}}},
+			Component{ID: roleID, Component: ComponentValue{Text: &TextComp{Value: label, UsageHint: "caption"}}},
+			Component{ID: contentID, Component: ComponentValue{Text: &TextComp{Value: body, UsageHint: "body"}}},
 		)
 	}
 	return emit(w, Message{SurfaceUpdate: &SurfaceUpdateMsg{SurfaceID: surfaceID, Components: comps}})

--- a/quickstart/chatwitheino/agent.go
+++ b/quickstart/chatwitheino/agent.go
@@ -71,7 +71,7 @@ func buildAgent(ctx context.Context) (adk.Agent, error) {
 	handlers = append(handlers, &approvalMiddleware{}, &safeToolMiddleware{})
 
 	return deep.New(ctx, &deep.Config{
-		Name:           "ChatWithDocAgent",
+		Name:           "ChatWithEinoAgent",
 		Description:    "An agent that reads and answers questions about documents.",
 		ChatModel:      cm,
 		Backend:        backend,

--- a/quickstart/chatwitheino/cmd/ch10/main.go
+++ b/quickstart/chatwitheino/cmd/ch10/main.go
@@ -1,0 +1,632 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ch10 demonstrates the full chat-with-eino web application using adk.Runner.
+// This is the "before TurnLoop" version — it has the complete web UI with sessions,
+// streaming, approval/interrupt, and file upload, but uses adk.Runner instead of
+// TurnLoop, so there is no preempt or abort support.
+//
+// Routes:
+//
+//	GET  /                        → serves static/index.html
+//	POST /sessions                → create a new session
+//	GET  /sessions                → list all sessions
+//	DELETE /sessions/:id          → delete a session
+//	POST /sessions/:id/chat       → stream agent response as SSE (A2UI JSONL)
+//	GET  /sessions/:id/render     → render session history as A2UI messages
+//	POST /sessions/:id/approve    → resume an interrupted agent with approval decision
+//	POST /sessions/:id/docs       → upload a document to the session workspace
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	hserver "github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/protocol/consts"
+	"github.com/google/uuid"
+	"github.com/hertz-contrib/sse"
+
+	localbk "github.com/cloudwego/eino-ext/adk/backend/local"
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/adk/prebuilt/deep"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/schema"
+
+	examplemodel "github.com/cloudwego/eino-examples/adk/common/model"
+	adkstore "github.com/cloudwego/eino-examples/adk/common/store"
+	commontool "github.com/cloudwego/eino-examples/adk/common/tool"
+	"github.com/cloudwego/eino-examples/quickstart/chatwitheino/a2ui"
+	"github.com/cloudwego/eino-examples/quickstart/chatwitheino/mem"
+	"github.com/cloudwego/eino-examples/quickstart/chatwitheino/rag"
+)
+
+func main() {
+	ctx := context.Background()
+
+	agent, err := buildAgent(ctx)
+	if err != nil {
+		log.Fatalf("build agent: %v", err)
+	}
+
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:           agent,
+		EnableStreaming:  true,
+		CheckPointStore: adkstore.NewInMemoryStore(),
+	})
+
+	sessionDir := os.Getenv("SESSION_DIR")
+	if sessionDir == "" {
+		sessionDir = "./data/sessions"
+	}
+	store, err := mem.NewStore(sessionDir)
+	if err != nil {
+		log.Fatalf("create store: %v", err)
+	}
+
+	workspaceDir := os.Getenv("WORKSPACE_DIR")
+	if workspaceDir == "" {
+		workspaceDir = "./data/workspace"
+	}
+
+	projectRoot := os.Getenv("PROJECT_ROOT")
+	if projectRoot == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			projectRoot = cwd
+		}
+	}
+	if abs, err := filepath.Abs(projectRoot); err == nil {
+		projectRoot = abs
+	}
+	log.Printf("project root: %s", projectRoot)
+
+	examplesDir := os.Getenv("EXAMPLES_DIR")
+	if examplesDir == "" {
+		candidate := filepath.Join(projectRoot, "examples")
+		if fi, err := os.Stat(candidate); err == nil && fi.IsDir() {
+			examplesDir = candidate
+		} else {
+			examplesDir = projectRoot
+		}
+	}
+	if abs, err := filepath.Abs(examplesDir); err == nil {
+		examplesDir = abs
+	}
+	log.Printf("examples dir: %s", examplesDir)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	srv := &server{
+		runner:       runner,
+		store:        store,
+		workspaceDir: workspaceDir,
+		projectRoot:  projectRoot,
+		examplesDir:  examplesDir,
+	}
+
+	h := hserver.Default(hserver.WithHostPorts(":" + port))
+
+	h.GET("/", func(_ context.Context, c *app.RequestContext) {
+		data, err := os.ReadFile("static/index.html")
+		if err != nil {
+			c.JSON(consts.StatusNotFound, map[string]string{"error": "index.html not found"})
+			return
+		}
+		c.Data(consts.StatusOK, "text/html; charset=utf-8", data)
+	})
+
+	h.POST("/sessions", func(_ context.Context, c *app.RequestContext) {
+		id := uuid.New().String()
+		if _, err := store.GetOrCreate(id); err != nil {
+			c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		c.JSON(consts.StatusOK, map[string]string{"id": id})
+	})
+
+	h.GET("/sessions", func(_ context.Context, c *app.RequestContext) {
+		metas, err := store.List()
+		if err != nil {
+			c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if metas == nil {
+			metas = []mem.SessionMeta{}
+		}
+		c.JSON(consts.StatusOK, metas)
+	})
+
+	h.DELETE("/sessions/:id", func(_ context.Context, c *app.RequestContext) {
+		id := c.Param("id")
+		if err := store.Delete(id); err != nil {
+			c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		c.Status(consts.StatusNoContent)
+	})
+
+	h.POST("/sessions/:id/chat", func(ctx context.Context, c *app.RequestContext) {
+		srv.handleChat(ctx, c)
+	})
+
+	h.GET("/sessions/:id/render", func(_ context.Context, c *app.RequestContext) {
+		srv.handleRender(c)
+	})
+
+	h.POST("/sessions/:id/approve", func(ctx context.Context, c *app.RequestContext) {
+		srv.handleApprove(ctx, c)
+	})
+
+	h.POST("/sessions/:id/abort", func(_ context.Context, c *app.RequestContext) {
+		// No-op: abort requires TurnLoop (introduced in the next chapter).
+		c.JSON(consts.StatusOK, map[string]string{"status": "not supported without TurnLoop"})
+	})
+
+	h.POST("/sessions/:id/docs", func(_ context.Context, c *app.RequestContext) {
+		srv.handleUpload(c)
+	})
+
+	log.Printf("starting server on http://localhost:%s", port)
+	h.Spin()
+}
+
+// server holds shared state for all handlers.
+type server struct {
+	runner       *adk.Runner
+	store        *mem.Store
+	workspaceDir string
+	projectRoot  string
+	examplesDir  string
+}
+
+// --- HTTP handlers ---
+
+type chatRequest struct {
+	Message string `json:"message"`
+}
+
+type approveRequest struct {
+	Approved bool   `json:"approved"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+func (s *server) handleChat(ctx context.Context, c *app.RequestContext) {
+	id := c.Param("id")
+
+	body, _ := c.Body()
+	var req chatRequest
+	if err := json.Unmarshal(body, &req); err != nil || req.Message == "" {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": "message is required"})
+		return
+	}
+
+	log.Printf("[chat] session=%s msg=%q", id, req.Message)
+
+	sess, err := s.store.GetOrCreate(id)
+	if err != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	userMsg := schema.UserMessage(req.Message)
+	if err := sess.Append(userMsg); err != nil {
+		log.Printf("warn: failed to persist user message: %v", err)
+	}
+
+	history := sess.GetMessages()
+	runMessages := s.buildRunMessages(id, history)
+	events := s.runner.Run(ctx, runMessages, adk.WithCheckPointID(id))
+
+	stream := sse.NewStream(c)
+	defer func() { _ = c.Flush() }()
+
+	lastContent, intermediates, interruptID, _, streamErr := a2ui.StreamToWriter(
+		&sseLineWriter{stream: stream}, id, history, events,
+	)
+
+	for _, msg := range intermediates {
+		if appendErr := sess.Append(msg); appendErr != nil {
+			log.Printf("warn: failed to persist intermediate: %v", appendErr)
+		}
+	}
+
+	if interruptID != "" {
+		sess.SetPendingInterruptID(interruptID)
+		log.Printf("[chat] session=%s interrupted: id=%s", id, interruptID)
+	} else if streamErr != nil {
+		log.Printf("[chat] session=%s error: %v", id, streamErr)
+	} else {
+		log.Printf("[chat] session=%s done, response=%d chars", id, len(lastContent))
+	}
+}
+
+func (s *server) handleRender(c *app.RequestContext) {
+	id := c.Param("id")
+	sess, err := s.store.GetOrCreate(id)
+	if err != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	var buf bytes.Buffer
+	if err := a2ui.RenderHistory(&buf, id, sess.GetMessages()); err != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	c.Data(consts.StatusOK, "application/x-ndjson", buf.Bytes())
+}
+
+func (s *server) handleApprove(ctx context.Context, c *app.RequestContext) {
+	id := c.Param("id")
+
+	sess, err := s.store.GetOrCreate(id)
+	if err != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	interruptID := sess.GetPendingInterruptID()
+	if interruptID == "" {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": "no pending interrupt for this session"})
+		return
+	}
+
+	body, _ := c.Body()
+	var req approveRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	var reason *string
+	if req.Reason != "" {
+		reason = &req.Reason
+	}
+	result := &commontool.ApprovalResult{Approved: req.Approved, DisapproveReason: reason}
+
+	sess.SetPendingInterruptID("")
+
+	log.Printf("[approve] session=%s interruptID=%s approved=%v", id, interruptID, req.Approved)
+
+	// Resume via Runner with the approval decision.
+	events, err2 := s.runner.ResumeWithParams(ctx, id, &adk.ResumeParams{
+		Targets: map[string]any{interruptID: result},
+	})
+	if err2 != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err2.Error()})
+		return
+	}
+
+	stream := sse.NewStream(c)
+	defer func() { _ = c.Flush() }()
+
+	msgIdx := sess.GetMsgIdx()
+	lastContent, newInterruptID, finalMsgIdx, streamErr := a2ui.StreamContinue(
+		&sseLineWriter{stream: stream}, id, msgIdx, events,
+	)
+	_ = finalMsgIdx
+
+	if newInterruptID != "" {
+		sess.SetPendingInterruptID(newInterruptID)
+		sess.SetMsgIdx(finalMsgIdx)
+		log.Printf("[approve] session=%s re-interrupted: id=%s", id, newInterruptID)
+	} else if streamErr != nil {
+		log.Printf("[approve] session=%s stream error: %v", id, streamErr)
+	} else {
+		log.Printf("[approve] session=%s done, response=%d chars", id, len(lastContent))
+	}
+}
+
+func (s *server) handleUpload(c *app.RequestContext) {
+	id := c.Param("id")
+
+	absWorkDir, err := filepath.Abs(filepath.Join(s.workspaceDir, id))
+	if err != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := os.MkdirAll(absWorkDir, 0o755); err != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": "file field is required"})
+		return
+	}
+
+	dst := filepath.Join(absWorkDir, filepath.Base(fileHeader.Filename))
+	if err := c.SaveUploadedFile(fileHeader, dst); err != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	c.JSON(consts.StatusOK, map[string]string{
+		"name": fileHeader.Filename,
+		"path": dst,
+	})
+}
+
+// buildRunMessages prepends a context message so the agent knows about the
+// project root and the session workspace. This message is never stored in history.
+func (s *server) buildRunMessages(sessionID string, history []*schema.Message) []*schema.Message {
+	var lines []string
+	lines = append(lines, "[Context]")
+	lines = append(lines,
+		"IMPORTANT RULES:",
+		"  1. Always use filesystem tools to look up real code before answering. Do not guess or make up information.",
+		"  2. After using tools (even if they return no results), you MUST write a text response to the user summarizing what you found.",
+		"  3. Never end your turn without a text response — tool calls alone are not sufficient.",
+		"  4. When asked to build or test code, use the execute tool to run the command.",
+		"     Each Go example has its own go.mod. To build an example, run:",
+		"       cd <example-dir> && go build ./...",
+		"     NEVER assume a build succeeded without actually running it.",
+		"  5. When writing or editing a file and then claiming it compiles, you MUST run the build tool to verify.",
+	)
+
+	if s.projectRoot != "" {
+		lines = append(lines,
+			fmt.Sprintf("Project root: %s", s.projectRoot),
+			"  IMPORTANT: Always pass the project root as the path argument when using filesystem tools.",
+			fmt.Sprintf("  - grep(pattern=\"...\", path=\"%s\")", s.projectRoot),
+			fmt.Sprintf("  - glob(pattern=\"%s/**/*.go\")", s.projectRoot),
+			fmt.Sprintf("  - read_file(file_path=\"%s/some/file.go\")", s.projectRoot),
+			"  grep and glob recurse into ALL subdirectories under the given path.",
+			"  Top-level subdirectories of the project root:",
+		)
+		if entries, err := os.ReadDir(s.projectRoot); err == nil {
+			for _, e := range entries {
+				if e.IsDir() {
+					lines = append(lines, "    - "+filepath.Join(s.projectRoot, e.Name())+"/")
+				}
+			}
+		}
+		lines = append(lines, "  Use these tools to read actual source code before answering questions about the codebase.")
+	}
+
+	if s.examplesDir != "" && s.examplesDir != s.projectRoot {
+		lines = append(lines,
+			fmt.Sprintf("eino-examples directory: %s", s.examplesDir),
+			"  When the user asks about examples or sample code, search here specifically:",
+			fmt.Sprintf("  - grep(pattern=\"...\", path=\"%s\")", s.examplesDir),
+			fmt.Sprintf("  - glob(pattern=\"%s/**/*.go\")", s.examplesDir),
+		)
+	}
+
+	absWorkDir, err := filepath.Abs(filepath.Join(s.workspaceDir, sessionID))
+	if err == nil {
+		entries, _ := os.ReadDir(absWorkDir)
+		var uploadedFiles []string
+		for _, e := range entries {
+			if !e.IsDir() {
+				uploadedFiles = append(uploadedFiles, filepath.Join(absWorkDir, e.Name()))
+			}
+		}
+		if len(uploadedFiles) > 0 {
+			lines = append(lines,
+				fmt.Sprintf("Session workspace: %s", absWorkDir),
+				"  Uploaded files:",
+			)
+			for _, f := range uploadedFiles {
+				lines = append(lines, "    - "+f)
+			}
+		}
+	}
+
+	ctx := strings.Join(lines, "\n")
+	runMessages := make([]*schema.Message, 0, len(history)+1)
+	runMessages = append(runMessages, schema.UserMessage(ctx))
+	runMessages = append(runMessages, history...)
+	return runMessages
+}
+
+// --- sseLineWriter ---
+
+type sseLineWriter struct {
+	stream *sse.Stream
+	buf    []byte
+}
+
+func (w *sseLineWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	for {
+		idx := -1
+		for i, b := range w.buf {
+			if b == '\n' {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			break
+		}
+		line := w.buf[:idx]
+		w.buf = w.buf[idx+1:]
+		if len(line) == 0 {
+			continue
+		}
+		if err := w.stream.Publish(&sse.Event{Data: line}); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+// --- Agent construction ---
+
+func buildAgent(ctx context.Context) (adk.Agent, error) {
+	cm := examplemodel.NewChatModel()
+
+	backend, err := localbk.NewBackend(ctx, &localbk.Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	ragTool, err := rag.BuildTool(ctx, cm)
+	if err != nil {
+		return nil, fmt.Errorf("build rag tool: %w", err)
+	}
+
+	handlers := []adk.ChatModelAgentMiddleware{&approvalMiddleware{}, &safeToolMiddleware{}}
+
+	return deep.New(ctx, &deep.Config{
+		Name:           "ChatWithEinoAgent",
+		Description:    "An agent that reads and answers questions about documents.",
+		ChatModel:      cm,
+		Backend:        backend,
+		StreamingShell: backend,
+		MaxIteration:   50,
+		Handlers:       handlers,
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []tool.BaseTool{ragTool},
+			},
+		},
+		ModelRetryConfig: &adk.ModelRetryConfig{
+			MaxRetries: 5,
+			IsRetryAble: func(_ context.Context, err error) bool {
+				return strings.Contains(err.Error(), "429") ||
+					strings.Contains(err.Error(), "Too Many Requests") ||
+					strings.Contains(err.Error(), "qpm limit")
+			},
+		},
+	})
+}
+
+// --- Middlewares ---
+
+type approvalMiddleware struct {
+	*adk.BaseChatModelAgentMiddleware
+}
+
+func (m *approvalMiddleware) WrapInvokableToolCall(
+	_ context.Context,
+	endpoint adk.InvokableToolCallEndpoint,
+	tCtx *adk.ToolContext,
+) (adk.InvokableToolCallEndpoint, error) {
+	if tCtx.Name != "answer_from_document" {
+		return endpoint, nil
+	}
+	return func(ctx context.Context, args string, opts ...tool.Option) (string, error) {
+		wasInterrupted, _, storedArgs := tool.GetInterruptState[string](ctx)
+		if !wasInterrupted {
+			return "", tool.StatefulInterrupt(ctx, &commontool.ApprovalInfo{
+				ToolName:        tCtx.Name,
+				ArgumentsInJSON: args,
+			}, args)
+		}
+
+		isTarget, hasData, data := tool.GetResumeContext[*commontool.ApprovalResult](ctx)
+		if isTarget && hasData {
+			if data.Approved {
+				return endpoint(ctx, storedArgs, opts...)
+			}
+			if data.DisapproveReason != nil {
+				return fmt.Sprintf("tool '%s' disapproved: %s", tCtx.Name, *data.DisapproveReason), nil
+			}
+			return fmt.Sprintf("tool '%s' disapproved", tCtx.Name), nil
+		}
+
+		isTarget, _, _ = tool.GetResumeContext[any](ctx)
+		if !isTarget {
+			return "", tool.StatefulInterrupt(ctx, &commontool.ApprovalInfo{
+				ToolName:        tCtx.Name,
+				ArgumentsInJSON: storedArgs,
+			}, storedArgs)
+		}
+
+		return endpoint(ctx, storedArgs, opts...)
+	}, nil
+}
+
+type safeToolMiddleware struct {
+	*adk.BaseChatModelAgentMiddleware
+}
+
+func (m *safeToolMiddleware) WrapInvokableToolCall(
+	_ context.Context,
+	endpoint adk.InvokableToolCallEndpoint,
+	_ *adk.ToolContext,
+) (adk.InvokableToolCallEndpoint, error) {
+	return func(ctx context.Context, args string, opts ...tool.Option) (string, error) {
+		result, err := endpoint(ctx, args, opts...)
+		if err != nil {
+			if _, ok := compose.IsInterruptRerunError(err); ok {
+				return "", err
+			}
+			return fmt.Sprintf("[tool error] %v", err), nil
+		}
+		return result, nil
+	}, nil
+}
+
+func (m *safeToolMiddleware) WrapStreamableToolCall(
+	_ context.Context,
+	endpoint adk.StreamableToolCallEndpoint,
+	_ *adk.ToolContext,
+) (adk.StreamableToolCallEndpoint, error) {
+	return func(ctx context.Context, args string, opts ...tool.Option) (*schema.StreamReader[string], error) {
+		sr, err := endpoint(ctx, args, opts...)
+		if err != nil {
+			if _, ok := compose.IsInterruptRerunError(err); ok {
+				return nil, err
+			}
+			return singleChunkReader(fmt.Sprintf("[tool error] %v", err)), nil
+		}
+		return safeWrapReader(sr), nil
+	}, nil
+}
+
+// --- Stream helpers ---
+
+func singleChunkReader(msg string) *schema.StreamReader[string] {
+	r, w := schema.Pipe[string](1)
+	_ = w.Send(msg, nil)
+	w.Close()
+	return r
+}
+
+func safeWrapReader(sr *schema.StreamReader[string]) *schema.StreamReader[string] {
+	r, w := schema.Pipe[string](64)
+	go func() {
+		defer w.Close()
+		for {
+			chunk, err := sr.Recv()
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			if err != nil {
+				_ = w.Send(fmt.Sprintf("\n[tool error] %v", err), nil)
+				return
+			}
+			_ = w.Send(chunk, nil)
+		}
+	}()
+	return r
+}

--- a/quickstart/chatwitheino/docs/ch01_chatmodel_agent_console.md
+++ b/quickstart/chatwitheino/docs/ch01_chatmodel_agent_console.md
@@ -193,14 +193,14 @@ if err != nil {
 defer stream.Close()
 
 for {
-    chunk, err := stream.Recv()
+    frame, err := stream.Recv()
     if errors.Is(err, io.EOF) {
         break
     }
     if err != nil {
         log.Fatal(err)
     }
-    fmt.Print(chunk.Content)
+    fmt.Print(frame.Content)
 }
 ```
 

--- a/quickstart/chatwitheino/docs/ch02_chatmodel_agent_runner_console.md
+++ b/quickstart/chatwitheino/docs/ch02_chatmodel_agent_runner_console.md
@@ -250,7 +250,7 @@ for {
     events := runner.Run(ctx, history)
     
     // 4. 消费事件流，收集 assistant 回复
-    content := collectAssistantFromEvents(events)
+    content := printAndCollectAssistantFromEvents(events)
     
     // 5. 追加 assistant 消息到 history
     history = append(history, schema.AssistantMessage(content, nil))

--- a/quickstart/chatwitheino/docs/ch03_memory_session_jsonl.md
+++ b/quickstart/chatwitheino/docs/ch03_memory_session_jsonl.md
@@ -162,7 +162,7 @@ if err := session.Append(userMsg); err != nil {
 ```go
 history := session.GetMessages()
 events := runner.Run(ctx, history)
-content := collectAssistantFromEvents(events)
+content := printAndCollectAssistantFromEvents(events)
 ```
 
 ### 5. 追加助手消息
@@ -192,7 +192,7 @@ if err := session.Append(userMsg); err != nil {
 // 调用 Agent
 history := session.GetMessages()
 events := runner.Run(ctx, history)
-content := collectAssistantFromEvents(events)
+content := printAndCollectAssistantFromEvents(events)
 
 // 保存助手回复
 assistantMsg := schema.AssistantMessage(content, nil)

--- a/quickstart/chatwitheino/docs/ch04_tool_backend_filesystem.md
+++ b/quickstart/chatwitheino/docs/ch04_tool_backend_filesystem.md
@@ -158,7 +158,7 @@ agent, err := deep.New(ctx, &deep.Config{
     Name:           "Ch04ToolAgent",
     Description:    "ChatWithDoc agent with filesystem access via LocalBackend.",
     ChatModel:      cm,
-    Instruction:    instruction,
+    Instruction:    agentInstruction,
     Backend:        backend,        // 提供文件系统操作能力
     StreamingShell: backend,        // 提供命令执行能力
     MaxIteration:   50,

--- a/quickstart/chatwitheino/docs/ch05_middleware.md
+++ b/quickstart/chatwitheino/docs/ch05_middleware.md
@@ -175,6 +175,9 @@ func (m *safeToolMiddleware) WrapInvokableToolCall(
     return func(ctx context.Context, args string, opts ...tool.Option) (string, error) {
         result, err := endpoint(ctx, args, opts...)
         if err != nil {
+            if _, ok := compose.IsInterruptRerunError(err); ok {
+                return "", err
+            }
             // 将错误转换为字符串，而不是返回错误
             return fmt.Sprintf("[tool error] %v", err), nil
         }
@@ -297,7 +300,8 @@ agent, err := deep.New(ctx, &deep.Config{
         MaxRetries: 5,
         IsRetryAble: func(_ context.Context, err error) bool {
             return strings.Contains(err.Error(), "429") ||
-                strings.Contains(err.Error(), "Too Many Requests")
+                strings.Contains(err.Error(), "Too Many Requests") ||
+                strings.Contains(err.Error(), "qpm limit")
         },
     },
 })

--- a/quickstart/chatwitheino/docs/ch06_callback.md
+++ b/quickstart/chatwitheino/docs/ch06_callback.md
@@ -238,48 +238,26 @@ callbacks.AppendGlobalHandlers(handler)
 ### 2. 集成 CozeLoop
 
 ```go
-func setupCozeLoop(ctx context.Context) (*cozeloop.Client, error) {
-    apiToken := os.Getenv("COZELOOP_API_TOKEN")
-    workspaceID := os.Getenv("COZELOOP_WORKSPACE_ID")
-    
-    if apiToken == "" || workspaceID == "" {
-        return nil, nil  // 未配置则跳过
-    }
-    
+// Setup CozeLoop tracing (optional)
+// Set COZELOOP_API_TOKEN and COZELOOP_WORKSPACE_ID to enable
+cozeloopApiToken := os.Getenv("COZELOOP_API_TOKEN")
+cozeloopWorkspaceID := os.Getenv("COZELOOP_WORKSPACE_ID")
+if cozeloopApiToken != "" && cozeloopWorkspaceID != "" {
     client, err := cozeloop.NewClient(
-        cozeloop.WithAPIToken(apiToken),
-        cozeloop.WithWorkspaceID(workspaceID),
+        cozeloop.WithAPIToken(cozeloopApiToken),
+        cozeloop.WithWorkspaceID(cozeloopWorkspaceID),
     )
     if err != nil {
-        return nil, err
+        log.Fatalf("cozeloop.NewClient failed: %v", err)
     }
-    
-    // 注册为全局 Callback
+    defer func() {
+        time.Sleep(5 * time.Second)
+        client.Close(ctx)
+    }()
     callbacks.AppendGlobalHandlers(clc.NewLoopHandler(client))
-    
-    return client, nil
-}
-```
-
-### 3. 在 main 中使用
-
-```go
-func main() {
-    ctx := context.Background()
-    
-    // 设置 CozeLoop（可选）
-    client, err := setupCozeLoop(ctx)
-    if err != nil {
-        log.Printf("cozeloop setup failed: %v", err)
-    }
-    if client != nil {
-        defer func() {
-            time.Sleep(5 * time.Second)  // 等待数据上报
-            client.Close(ctx)
-        }()
-    }
-    
-    // 创建 Agent 并运行...
+    log.Println("CozeLoop tracing enabled")
+} else {
+    log.Println("CozeLoop tracing disabled (set COZELOOP_API_TOKEN and COZELOOP_WORKSPACE_ID to enable)")
 }
 ```
 

--- a/quickstart/chatwitheino/docs/ch07_interrupt_resume.md
+++ b/quickstart/chatwitheino/docs/ch07_interrupt_resume.md
@@ -165,11 +165,15 @@ func (m *approvalMiddleware) WrapInvokableToolCall(
             return fmt.Sprintf("tool '%s' disapproved", tCtx.Name), nil
         }
         
-        // 重新中断
-        return "", tool.StatefulInterrupt(ctx, &commontool.ApprovalInfo{
-            ToolName:        tCtx.Name,
-            ArgumentsInJSON: storedArgs,
-        }, storedArgs)
+        isTarget, _, _ = tool.GetResumeContext[any](ctx)
+        if !isTarget {
+            return "", tool.StatefulInterrupt(ctx, &commontool.ApprovalInfo{
+                ToolName:        tCtx.Name,
+                ArgumentsInJSON: storedArgs,
+            }, storedArgs)
+        }
+
+        return endpoint(ctx, storedArgs, opts...)
     }, nil
 }
 

--- a/quickstart/chatwitheino/docs/ch08_graph_tool.md
+++ b/quickstart/chatwitheino/docs/ch08_graph_tool.md
@@ -124,8 +124,8 @@ wf.AddLambdaNode("answer", answerFunc).
 
 ```go
 type Input struct {
-    FilePath string `json:"file_path" jsonschema:"description=Absolute path to the document"`
-    Question string `json:"question"  jsonschema:"description=The question to answer"`
+    FilePath string `json:"file_path" jsonschema:"description=Absolute path to the uploaded document file"`
+    Question string `json:"question"  jsonschema:"description=The question to answer from the document"`
 }
 
 type Output struct {
@@ -181,23 +181,35 @@ func buildWorkflow(cm model.BaseChatModel) *compose.Workflow[Input, Output] {
         AddInputWithOptions("chunk", []*compose.FieldMapping{compose.ToField("Chunks")}, compose.WithNoDirectDependency()).
         AddInputWithOptions(compose.START, []*compose.FieldMapping{compose.MapFields("Question", "Question")}, compose.WithNoDirectDependency())
 
-    // filter: 筛选 top-k
+    // filter: sort descending by score, keep up to top-3 chunks with score ≥ 3.
     wf.AddLambdaNode("filter", compose.InvokableLambda(
         func(ctx context.Context, scored []scoredChunk) ([]scoredChunk, error) {
             sort.Slice(scored, func(i, j int) bool {
                 return scored[i].Score > scored[j].Score
             })
-            // 返回 top-3
-            if len(scored) > 3 {
-                scored = scored[:3]
+            const maxK = 3
+            var top []scoredChunk
+            for _, c := range scored {
+                if c.Score < 3 {
+                    break
+                }
+                top = append(top, c)
+                if len(top) == maxK {
+                    break
+                }
             }
-            return scored, nil
+            return top, nil
         },
     )).AddInput("score")
 
-    // answer: 生成答案
+    // answer: synthesize a response from top-k chunks, or return a not-found message if empty.
     wf.AddLambdaNode("answer", compose.InvokableLambda(
         func(ctx context.Context, in synthIn) (Output, error) {
+            if len(in.TopK) == 0 {
+                return Output{
+                    Answer: fmt.Sprintf("No relevant content found in the document for: %q", in.Question),
+                }, nil
+            }
             return synthesize(ctx, cm, in)
         },
     )).
@@ -218,7 +230,9 @@ func BuildTool(ctx context.Context, cm model.BaseChatModel) (tool.BaseTool, erro
     return graphtool.NewInvokableGraphTool[Input, Output](
         wf,
         "answer_from_document",
-        "Search a large document for relevant content and synthesize an answer.",
+        "Search a large uploaded document for content relevant to a question and synthesize a "+
+            "cited answer from the most relevant passages. "+
+            "Use this instead of read_file when the document may be too large to fit in context.",
     )
 }
 ```

--- a/quickstart/chatwitheino/docs/ch10_a2ui.md
+++ b/quickstart/chatwitheino/docs/ch10_a2ui.md
@@ -18,9 +18,7 @@ Eino 更关注“可组合的智能执行与编排能力”，至于“如何呈
 
 ## 代码位置
 
-- 入口代码：[main.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/main.go)
-- Agent 构建：[agent.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/agent.go)
-- 服务端路由：[server/server.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/server/server.go)
+- 入口代码（Runner 版）：[cmd/ch10/main.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/cmd/ch10/main.go)
 - A2UI 子集实现：[a2ui/types.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/a2ui/types.go)
 - A2UI 事件流转换：[a2ui/streamer.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/a2ui/streamer.go)
 - 前端页面：[static/index.html](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/static/index.html)
@@ -34,7 +32,7 @@ Eino 更关注“可组合的智能执行与编排能力”，至于“如何呈
 在 `quickstart/chatwitheino` 目录下执行：
 
 ```bash
-go run .
+go run ./cmd/ch10/
 ```
 
 输出示例：
@@ -49,7 +47,7 @@ starting server on http://localhost:8080
 
 ```bash
 go run ./scripts/sync_eino_ext_skills.go -src /path/to/eino-ext -dest ./skills/eino-ext -clean
-EINO_EXT_SKILLS_DIR="$(pwd)/skills/eino-ext" go run .
+EINO_EXT_SKILLS_DIR="$(pwd)/skills/eino-ext" go run ./cmd/ch10/
 ```
 
 ## 从文本到 UI：为什么需要 A2UI
@@ -120,7 +118,7 @@ type Message struct {
 
 ### 服务端路由（高层）
 
-与 A2UI 相关的关键接口（见 [server/server.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/server/server.go)）：
+与 A2UI 相关的关键接口（见 [cmd/ch10/main.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/cmd/ch10/main.go)）：
 
 - `GET /`：返回前端页面 `static/index.html`
 - `POST /sessions/:id/chat`：返回 SSE 流（A2UI messages），把 Agent 运行结果边跑边渲染到 UI
@@ -212,31 +210,8 @@ while (true) {
 - **流式输出**：后端以 SSE 推送 A2UI JSONL，前端增量渲染组件树
 - **事件到 UI**：把 `AgentEvent` 转为 `tool call / tool result / assistant stream` 的可视化输出
 
-## 系列收尾：这个 Quickstart Agent 的完整愿景
+## 下一步
 
-到本章为止，我们用一个可以实际运行的 Agent 串起了 Eino 的核心能力。你可以把它理解为一个可扩展的“端到端 Agent 应用骨架”：
+本章的 `cmd/ch10` 使用 `adk.Runner` 实现了完整的 Web 应用。但 Runner 是"一次性"模型——如果用户在 Agent 回答到一半时发出新问题，Runner 没有内置机制来取消当前执行并切换到新输入。
 
-- 运行时：Runner 驱动执行，支持流式输出与事件模型
-- 工具层：Filesystem / Shell 等 Tool 能力接入，工具错误可被安全处理
-- 中间件：可插拔的 middleware/handler，用于错误处理、重试、审批等横切能力
-- 可观测：callbacks/trace 能力把关键链路打通，便于调试与线上观测
-- 人机协作：interrupt/resume + checkpoint 支持审批、补参、分支选择等交互式流程
-- 确定性编排：compose（graph/chain/workflow）把复杂业务流程组织为可维护、可复用的执行图
-- 业务交付：像 A2UI 这样的 UI 集成，属于业务层自由选择的一环，用来把 Agent 能力以合适的产品形态呈现给用户
-
-你可以在这个骨架上逐步替换/扩展任意环节：模型、工具、存储、工作流、前端渲染协议，而不需要推倒重来。
-
-## 扩展思考
-
-**其他组件类型：**
-- 图表组件（折线图、柱状图、饼图）
-- 地图组件
-- 时间线组件
-- 树形组件
-- 标签页组件
-
-**高级功能：**
-- 组件交互（点击、拖拽、输入）
-- 条件渲染
-- 组件动画
-- 响应式布局
+下一章将引入 `adk.TurnLoop`，为 Agent 增加 **抢占（Preempt）** 和 **中止（Abort）** 能力。

--- a/quickstart/chatwitheino/docs/ch11_turnloop.md
+++ b/quickstart/chatwitheino/docs/ch11_turnloop.md
@@ -1,0 +1,238 @@
+---
+title: "第十一章：TurnLoop — 抢占、中止与多轮生命周期"
+---
+
+上一章我们用 `adk.Runner` 实现了完整的 A2UI Web 应用。它能正常工作，但试试这个场景：
+
+> 你问 Agent 一个复杂问题，它开始调用工具、生成长回答……但你忽然意识到问错了，想换一个问题。
+
+在上一章的 Runner 模式下，你只能等它说完，或者刷新页面丢弃一切。
+
+本章引入 `adk.TurnLoop`，让 Agent 支持两个用户侧可感知的新能力：**抢占**和**中止**。
+
+## 前置条件
+
+与第一章一致：需要配置一个可用的 ChatModel（OpenAI 或 Ark），详见第一章的"前置条件"部分。
+
+## 运行 & 体验
+
+在 `quickstart/chatwitheino` 目录下执行：
+
+```bash
+go run .
+```
+
+打开浏览器访问 `http://localhost:8080`，然后试试以下操作：
+
+### 体验抢占（Preempt）
+
+1. 发送一个会触发长回答的问题，例如"详细解释一下 Eino 的所有组件"
+2. **在 Agent 还在回答时**，直接发送一条新消息，例如"算了，就告诉我 ChatModel 是什么"
+3. 观察：旧回答立即停止，Agent 开始回答新问题
+
+### 体验中止（Abort）
+
+1. 发送一个问题
+2. **在 Agent 回答过程中**，点击右上角的 **Abort 按钮**
+3. 观察：Agent 立即停止，不再继续输出
+
+这两个能力在上一章的 Runner 版本中都不存在。以下解释它们是如何实现的。
+
+## 代码位置
+
+- 入口代码：[main.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/main.go)
+- Agent 构建：[agent.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/agent.go)
+- TurnLoop 服务端：[server/server.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/server/server.go)
+
+## 为什么 Runner 做不到
+
+上一章的 `cmd/ch10` 中，每个 `/sessions/:id/chat` 请求调用一次 `runner.Run(ctx, messages)`。Runner 是**单轮（single-turn）**模型——调用一次、执行一次、结束。如果用户在 Agent 执行过程中又发了一条消息，Runner 没有"正在运行的循环"可以接收它。
+
+TurnLoop 则是一个**持久运行的多轮（multi-turn）执行循环**。它在轮次之间保持 idle 等待，随时可以通过 `Push()` 接收新输入并立即响应。正是因为有一个持续运行的循环，抢占和中止才成为可能——你可以打断一个正在进行的轮次，或者直接停止整个循环。
+
+| 能力 | Ch10（Runner，单轮） | Ch11（TurnLoop，多轮） |
+|------|---------------------|----------------------|
+| 流式输出 | ✅ | ✅ |
+| 审批/中断 | ✅ | ✅ |
+| 跨轮次持久运行、实时响应新输入 | ❌ 每次 `Run()` 独立 | ✅ `Push()` 随时送入 |
+| 抢占正在进行的回答 | ❌ | ✅ `Push(item, WithPreempt(...))` |
+| 中止 Agent | ❌ | ✅ `loop.Stop(WithImmediate())` |
+| 灵活的 per-turn 输入构建 | ❌ 业务层手动拼装 | ✅ `GenInput` 回调 |
+
+## TurnLoop 的核心模型
+
+TurnLoop 是一个**基于推送的事件循环，以轮次（turn）为单位管理 Agent 的执行**。与 Runner 的"调用一次、执行一次"不同，TurnLoop 持续运行：轮次结束后进入 idle 等待，新 item 到来时立即启动下一轮。
+
+```
+Push(item) → [队列] → GenInput(items) → Agent.Run() → OnAgentEvents(events)
+                                ↑                              │
+                                └──── idle 等待 / 下一轮 ←──────┘
+```
+
+关键概念：
+
+- **Item**：用户输入的载体。本示例定义为 `ChatItem`，可以携带用户消息或审批决定
+- **GenInput**：从队列中的 items 构建 Agent 输入（选择哪些 items 消费、哪些保留给下一轮）
+- **OnAgentEvents**：接收 Agent 输出的事件流，负责渲染和持久化
+- **Push**：向队列推入新 item，可附带抢占选项
+
+## 一个 Session 对应一个 TurnLoop
+
+在本示例的 Web 场景中，每个聊天 session 对应一个 TurnLoop 实例。当用户发送第一条消息时，服务端为该 session 创建一个 TurnLoop 并调用 `Run()` 启动它；后续消息通过 `Push()` 送入同一个循环。这个循环在轮次之间保持 idle 等待，直到 session 被删除或用户 abort。
+
+这是 TurnLoop 最典型的使用模式：**循环的生命周期与用户会话绑定**。一个长期运行的 TurnLoop 让抢占和中止成为自然的操作——因为"正在运行的循环"始终存在，新输入随时可以送入。
+
+## 常规流程：idle → 新消息 → 回答 → idle
+
+最简单的场景是用户依次提问、等回答、再提下一个问题：
+
+```go
+// 用户发送第一条消息时，创建并启动 TurnLoop
+loop := adk.NewTurnLoop(cfg)
+loop.Push(&ChatItem{Query: "hello"})
+loop.Run(ctx)
+// → GenInput 构建输入 → Agent 执行 → OnAgentEvents 流式输出
+// → 轮次结束，TurnLoop 进入 idle 等待
+
+// 用户发送第二条消息（此时 loop 处于 idle）
+loop.Push(&ChatItem{Query: "explain Eino's architecture"})
+// → TurnLoop 唤醒，开始新一轮：GenInput → Agent → OnAgentEvents → idle
+```
+
+这个流程与上一章的 Runner 在用户体验上没有区别——区别在于 TurnLoop 的循环**持续存在**，不需要每次都重新创建。而一旦用户在 Agent 还在回答时发来新消息，就进入了下面的"抢占"场景。
+
+## 抢占是怎么实现的
+
+当用户在 Agent 回答过程中发送新消息时，业务层只需一行代码触发抢占：
+
+```go
+loop.Push(item, adk.WithPreempt[*ChatItem, *schema.Message](adk.AfterToolCalls))
+```
+
+TurnLoop 收到这个指令后：
+
+1. 等待当前 tool call 完成（`AfterToolCalls` 表示不打断正在执行的工具，避免不一致状态）
+2. 取消当前轮次——OnAgentEvents 的 context 被取消，旧轮次退出
+3. 从队列取出新 item，通过 GenInput 构建输入，启动新一轮
+
+抢占模式可以根据业务需要选择不同的安全点：
+
+| 模式 | 行为 |
+|------|------|
+| `AfterToolCalls` | 等当前 tool call 完成后取消（推荐，避免工具执行到一半） |
+| `AfterChatModel` | 等当前 model 调用完成后取消 |
+| `AnySafePoint` | 任一安全点即取消 |
+
+> 本示例中 TurnLoop 运行在独立 goroutine 中，而 HTTP handler 需要把事件流写入 SSE 响应。两者之间通过 channel 协调（见 [server/server.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/server/server.go) 中的 `iterEnvelope`/`iterResult` 以及 `handlerDone` 信号机制）。这些是 HTTP 适配层的细节，不属于 TurnLoop API 本身。
+
+## 中止是怎么实现的
+
+中止更简单——直接停止整个 TurnLoop：
+
+```go
+loop.Stop(adk.WithImmediate())  // 立即取消，不等待当前轮次
+loop.Wait()                     // 等待完全退出
+```
+
+### Stop 的三种模式
+
+| 模式 | 行为 |
+|------|------|
+| `loop.Stop()` | 轮次边界退出：等待当前轮次完成后退出 |
+| `loop.Stop(WithImmediate())` | 立即退出：取消当前轮次的 context |
+| `loop.Stop(WithGraceful())` | 安全点退出：在下一个安全点（如 tool call 之间）退出 |
+
+## TurnLoop 的配置
+
+创建 TurnLoop 时，通过 `TurnLoopConfig` 指定回调和选项：
+
+```go
+cfg := adk.TurnLoopConfig[*ChatItem, *schema.Message]{
+    // GenInput：每轮开始时调用，决定"这一轮 Agent 看到什么"
+    // 从队列中选择 items 构建 Agent 输入，返回 Consumed（本轮处理）和 Remaining（留到后续轮次）
+    GenInput: func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], items []*ChatItem) (*adk.GenInputResult[*ChatItem, *schema.Message], error) {
+        // ...构建 AgentInput，持久化用户消息...
+    },
+
+    // PrepareAgent：每轮调用一次，返回本轮使用的 Agent
+    // 本示例直接返回同一个 Agent，但你可以根据 items 动态选择不同 Agent
+    PrepareAgent: func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], consumed []*ChatItem) (adk.Agent, error) {
+        return agent, nil
+    },
+
+    // OnAgentEvents：接收 Agent 的事件流，负责渲染输出和持久化中间消息
+    // 本示例通过 channel 把事件流转交给 HTTP handler 做 SSE 输出
+    OnAgentEvents: func(ctx context.Context, tc *adk.TurnContext[*ChatItem, *schema.Message], events *adk.AsyncIterator[*adk.AgentEvent]) error {
+        // ...把 events 交给 HTTP handler，等待消费完成...
+    },
+
+    // 以下三个字段用于声明式 checkpoint（审批恢复），下一节详细介绍
+    GenResume:    makeGenResume(),
+    Store:        checkpointStore,
+    CheckpointID: sessionID,
+}
+
+loop := adk.NewTurnLoop(cfg)
+```
+
+| 回调 | 调用时机 | 职责 |
+|------|---------|------|
+| `GenInput` | 队列中有 items 时 | 选择消费哪些 items，构建 Agent 输入 |
+| `PrepareAgent` | GenInput 之后 | 返回本轮使用的 Agent 实例 |
+| `OnAgentEvents` | Agent 产出事件流时 | 消费事件、渲染输出、持久化 |
+| `GenResume` | 从 checkpoint 恢复时 | 用审批结果构建 ResumeParams（见下一节） |
+| `Store` + `CheckpointID` | — | 启用声明式 checkpoint（见下一节） |
+
+> 完整的回调实现请参考 [server/server.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/server/server.go)。
+
+## 声明式 Checkpoint：审批恢复的自动化
+
+在第七章（Runner 模式）中，审批恢复需要业务层手动调用 `runner.ResumeWithParams()`，自己判断"这次是正常执行还是恢复执行"。TurnLoop 提供了更简洁的方式——在配置中声明 `Store` 和 `CheckpointID`（见上一节），TurnLoop 会自动处理保存与恢复：
+
+1. Agent 执行到审批 interrupt 时，TurnLoop 自动将执行状态保存到 `Store`（以 `CheckpointID` 为 key）
+2. 用户做出审批决定后，业务层创建一个新的 TurnLoop（使用**相同的** `CheckpointID`），并 Push 审批 item
+3. 新 TurnLoop `Run()` 时，检测到 checkpoint 存在，**自动调用 `GenResume`**（而非 `GenInput`）获取恢复参数
+4. Agent 从 interrupt 点继续执行
+
+`GenResume` 的职责就是从新 Push 进来的 items 中提取审批结果，构建 `ResumeParams`：
+
+```go
+GenResume: func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message],
+    canceledItems, unhandledItems, newItems []*ChatItem,
+) (*adk.GenResumeResult[*ChatItem, *schema.Message], error) {
+    // newItems 包含审批恢复时 Push 的 item
+    item := newItems[0]
+    return &adk.GenResumeResult[*ChatItem, *schema.Message]{
+        ResumeParams: &adk.ResumeParams{
+            InterruptID: item.InterruptID,
+            ApprovalResult: item.ApprovalResult,
+        },
+    }, nil
+}
+```
+
+相比 Runner 的 `ResumeWithParams()`，声明式 checkpoint 让业务层不需要管理"正常执行 vs 恢复执行"的分支——TurnLoop 根据 checkpoint 是否存在自动选择走 `GenInput` 还是 `GenResume`。
+
+## 本章小结
+
+- **TurnLoop** 是一个持久运行的多轮执行循环，生命周期与用户会话绑定
+- **常规流程**：`Push(item)` → GenInput → Agent → OnAgentEvents → idle → 等待下一个 Push
+- **抢占**：`Push(item, WithPreempt(AfterToolCalls))` 一行代码取消当前轮次并开始新一轮
+- **中止**：`loop.Stop(WithImmediate())` 一行代码终止整个循环
+- **声明式 checkpoint**：配置 `Store` + `CheckpointID`，TurnLoop 自动处理 interrupt 的保存与恢复
+- 回调的具体实现请参考 [server/server.go](https://github.com/cloudwego/eino-examples/blob/main/quickstart/chatwitheino/server/server.go)
+
+## 系列收尾：完整 Agent 应用骨架
+
+到本章为止，我们用一个可以实际运行的 Agent 串起了 Eino 的核心能力：
+
+- **运行时**：Runner / TurnLoop 驱动执行，支持流式输出、抢占与中止
+- **工具层**：Filesystem / Shell 等 Tool 能力接入，工具错误可被安全处理
+- **中间件**：可插拔的 middleware/handler，用于错误处理、重试、审批等横切能力
+- **可观测**：callbacks/trace 能力把关键链路打通，便于调试与线上观测
+- **人机协作**：interrupt/resume + checkpoint 支持审批、补参、分支选择等交互式流程
+- **确定性编排**：compose（graph/chain/workflow）把复杂业务流程组织为可维护、可复用的执行图
+- **业务交付**：A2UI 协议把 Agent 能力以流式 UI 的形式呈现给用户
+- **执行控制**：TurnLoop 提供抢占、中止、多轮生命周期管理，适配真实业务场景的复杂交互需求
+
+你可以在这个骨架上逐步替换/扩展任意环节：模型、工具、存储、工作流、前端渲染协议，而不需要推倒重来。

--- a/quickstart/chatwitheino/main.go
+++ b/quickstart/chatwitheino/main.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	clc "github.com/cloudwego/eino-ext/callbacks/cozeloop"
-	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/callbacks"
 	"github.com/coze-dev/cozeloop-go"
 
@@ -61,11 +60,7 @@ func main() {
 		log.Fatalf("failed to build agent: %v", err)
 	}
 
-	runner := adk.NewRunner(ctx, adk.RunnerConfig{
-		Agent:           agent,
-		EnableStreaming: true,
-		CheckPointStore: adkstore.NewInMemoryStore(),
-	})
+	checkpointStore := adkstore.NewInMemoryStore()
 
 	sessionDir := os.Getenv("SESSION_DIR")
 	if sessionDir == "" {
@@ -117,12 +112,13 @@ func main() {
 	log.Printf("examples dir: %s", examplesDir)
 
 	srv := server.New(server.Config{
-		Runner:       runner,
-		Store:        store,
-		WorkspaceDir: workspaceDir,
-		ProjectRoot:  projectRoot,
-		ExamplesDir:  examplesDir,
-		Port:         port,
+		Agent:           agent,
+		CheckPointStore: checkpointStore,
+		Store:           store,
+		WorkspaceDir:    workspaceDir,
+		ProjectRoot:     projectRoot,
+		ExamplesDir:     examplesDir,
+		Port:            port,
 	})
 
 	log.Printf("starting server on http://localhost:%s", port)

--- a/quickstart/chatwitheino/server/server.go
+++ b/quickstart/chatwitheino/server/server.go
@@ -102,10 +102,11 @@ type iterResult struct {
 
 // sessionTurnState holds the TurnLoop and event bridge channels for a session.
 type sessionTurnState struct {
-	mu        sync.Mutex
-	loop      *adk.TurnLoop[*ChatItem]
-	iterReady chan iterEnvelope // OnAgentEvents → HTTP handler
-	iterDone  chan iterResult   // HTTP handler → OnAgentEvents
+	mu          sync.Mutex
+	loop        *adk.TurnLoop[*ChatItem, *schema.Message]
+	iterReady   chan iterEnvelope // OnAgentEvents → HTTP handler
+	iterDone    chan iterResult   // HTTP handler → OnAgentEvents
+	handlerDone chan struct{}     // closed to tell a prev handler to bail on preempt
 }
 
 func (s *Server) getTurnState(sessionID string) *sessionTurnState {
@@ -117,7 +118,7 @@ func (s *Server) getTurnState(sessionID string) *sessionTurnState {
 // (e.g. due to an error or all items consumed) and nils out ts.loop so
 // the next handleChat creates a fresh loop instead of trying to preempt
 // a dead one.
-func (s *Server) startLoopCleanup(ts *sessionTurnState, loop *adk.TurnLoop[*ChatItem], sessionID string) {
+func (s *Server) startLoopCleanup(ts *sessionTurnState, loop *adk.TurnLoop[*ChatItem, *schema.Message], sessionID string) {
 	go func() {
 		result := loop.Wait()
 		ts.mu.Lock()
@@ -256,15 +257,29 @@ func (s *Server) handleChat(ctx context.Context, c *app.RequestContext) {
 	item := &ChatItem{Query: req.Message}
 
 	ts := s.getTurnState(id)
+
+	// Each handler gets its own local iterReady channel reference and a
+	// handlerDone channel. This avoids races when multiple preempts replace
+	// the channels on ts concurrently.
+	var localIterReady chan iterEnvelope
+	var localHandlerDone chan struct{}
+
 	ts.mu.Lock()
 	if ts.loop != nil {
 		// Loop exists — try to push with preempt (AfterToolCalls).
 		loop := ts.loop
 		log.Printf("[chat] session=%s preempting current turn", id)
+		// Signal any previous handler waiting on iterReady to bail.
+		if ts.handlerDone != nil {
+			close(ts.handlerDone)
+		}
 		ts.iterReady = make(chan iterEnvelope, 1)
 		ts.iterDone = make(chan iterResult, 1)
+		ts.handlerDone = make(chan struct{})
+		localIterReady = ts.iterReady
+		localHandlerDone = ts.handlerDone
 		ts.mu.Unlock()
-		ok, _ := loop.Push(item, adk.WithPreempt[*ChatItem](adk.AfterToolCalls))
+		ok, _ := loop.Push(item, adk.WithPreempt[*ChatItem, *schema.Message](adk.AfterToolCalls))
 		if !ok {
 			// Loop already stopped (e.g. error on previous turn) — create new one.
 			log.Printf("[chat] session=%s loop was dead, creating new loop", id)
@@ -273,6 +288,9 @@ func (s *Server) handleChat(ctx context.Context, c *app.RequestContext) {
 			ts.loop = loop
 			ts.iterReady = make(chan iterEnvelope, 1)
 			ts.iterDone = make(chan iterResult, 1)
+			ts.handlerDone = make(chan struct{})
+			localIterReady = ts.iterReady
+			localHandlerDone = ts.handlerDone
 			ts.mu.Unlock()
 			loop.Push(item)
 			loop.Run(context.Background())
@@ -284,6 +302,9 @@ func (s *Server) handleChat(ctx context.Context, c *app.RequestContext) {
 		ts.loop = loop
 		ts.iterReady = make(chan iterEnvelope, 1)
 		ts.iterDone = make(chan iterResult, 1)
+		ts.handlerDone = make(chan struct{})
+		localIterReady = ts.iterReady
+		localHandlerDone = ts.handlerDone
 		ts.mu.Unlock()
 		loop.Push(item)
 		loop.Run(context.Background())
@@ -294,16 +315,10 @@ func (s *Server) handleChat(ctx context.Context, c *app.RequestContext) {
 	// session history ordering: the preempted turn's intermediates are persisted
 	// by OnAgentEvents before GenInput fires for the new turn.
 
-	// Wait for OnAgentEvents to send us the iterator.
-	var envelope iterEnvelope
-	select {
-	case envelope = <-ts.iterReady:
-	case <-time.After(60 * time.Second):
-		c.JSON(consts.StatusGatewayTimeout, map[string]string{"error": "agent did not start in time"})
-		return
-	}
-
-	// Open SSE stream.
+	// Open SSE stream and start keepalives BEFORE waiting for the iterator.
+	// During a preempt the old turn may take tens of seconds to drain; if we
+	// don't write anything the browser/TCP stack may consider the connection
+	// dead, causing all subsequent writes to fail silently.
 	stream := sse.NewStream(c)
 	defer func() { _ = c.Flush() }()
 
@@ -320,6 +335,25 @@ func (s *Server) handleChat(ctx context.Context, c *app.RequestContext) {
 			}
 		}
 	}()
+
+	// Wait for OnAgentEvents to send us the iterator. Use local channel
+	// references so a concurrent preempt replacing ts.iterReady doesn't
+	// orphan us on a stale channel.
+	var envelope iterEnvelope
+	select {
+	case envelope = <-localIterReady:
+	case <-localHandlerDone:
+		// Another preempt took over — our turn was superseded.
+		close(kaStop)
+		log.Printf("[chat] session=%s handler superseded by newer preempt", id)
+		_ = stream.Publish(&sse.Event{Data: []byte(`{"event":"preempted"}`)})
+		return
+	case <-time.After(60 * time.Second):
+		close(kaStop)
+		// Stream is already open; send an error event instead of JSON.
+		_ = stream.Publish(&sse.Event{Data: []byte(`{"error":"agent did not start in time"}`)})
+		return
+	}
 
 	lastContent, intermediates, interruptID, finalMsgIdx, streamErr := a2ui.StreamToWriter(
 		&sseLineWriter{stream: stream}, id, envelope.history, envelope.events,
@@ -386,10 +420,17 @@ func (s *Server) handleApprove(ctx context.Context, c *app.RequestContext) {
 	if ts.loop != nil {
 		ts.loop.Stop(adk.WithImmediate())
 	}
+	// Signal any previous handler to bail.
+	if ts.handlerDone != nil {
+		close(ts.handlerDone)
+	}
 	loop := s.newLoop(sess, id, true)
 	ts.loop = loop
 	ts.iterReady = make(chan iterEnvelope, 1)
 	ts.iterDone = make(chan iterResult, 1)
+	ts.handlerDone = make(chan struct{})
+	localIterReady := ts.iterReady
+	localHandlerDone := ts.handlerDone
 	ts.mu.Unlock()
 
 	// Push the approval item before starting.
@@ -400,16 +441,7 @@ func (s *Server) handleApprove(ctx context.Context, c *app.RequestContext) {
 	loop.Run(context.Background())
 	s.startLoopCleanup(ts, loop, id)
 
-	// Wait for OnAgentEvents to send us the iterator.
-	var envelope iterEnvelope
-	select {
-	case envelope = <-ts.iterReady:
-	case <-time.After(60 * time.Second):
-		c.JSON(consts.StatusGatewayTimeout, map[string]string{"error": "agent did not start in time"})
-		return
-	}
-	_ = envelope.history // not used for StreamContinue
-
+	// Open SSE stream and start keepalives before waiting.
 	stream := sse.NewStream(c)
 	defer func() { _ = c.Flush() }()
 
@@ -426,6 +458,22 @@ func (s *Server) handleApprove(ctx context.Context, c *app.RequestContext) {
 			}
 		}
 	}()
+
+	// Wait for OnAgentEvents to send us the iterator.
+	var envelope iterEnvelope
+	select {
+	case envelope = <-localIterReady:
+	case <-localHandlerDone:
+		close(kaStop)
+		log.Printf("[approve] session=%s handler superseded by newer request", id)
+		_ = stream.Publish(&sse.Event{Data: []byte(`{"event":"preempted"}`)})
+		return
+	case <-time.After(60 * time.Second):
+		close(kaStop)
+		_ = stream.Publish(&sse.Event{Data: []byte(`{"error":"agent did not start in time"}`)})
+		return
+	}
+	_ = envelope.history // not used for StreamContinue
 
 	lastContent, newInterruptID, finalMsgIdx, streamErr := a2ui.StreamContinue(
 		&sseLineWriter{stream: stream}, id, sess.GetMsgIdx(), envelope.events,
@@ -474,8 +522,8 @@ func (s *Server) handleAbort(_ context.Context, c *app.RequestContext) {
 
 // newLoop creates a new TurnLoop for the session. If withResume is true,
 // the loop is configured with a checkpoint store and GenResume for interrupt resume.
-func (s *Server) newLoop(sess *mem.Session, sessionID string, withResume bool) *adk.TurnLoop[*ChatItem] {
-	cfg := adk.TurnLoopConfig[*ChatItem]{
+func (s *Server) newLoop(sess *mem.Session, sessionID string, withResume bool) *adk.TurnLoop[*ChatItem, *schema.Message] {
+	cfg := adk.TurnLoopConfig[*ChatItem, *schema.Message]{
 		GenInput:      s.makeGenInput(sess, sessionID),
 		PrepareAgent:  s.makePrepareAgent(),
 		OnAgentEvents: s.makeOnAgentEvents(sess, sessionID),
@@ -490,8 +538,8 @@ func (s *Server) newLoop(sess *mem.Session, sessionID string, withResume bool) *
 
 // makeGenInput returns the GenInput callback. It builds agent messages from
 // session history + workspace context.
-func (s *Server) makeGenInput(sess *mem.Session, sessionID string) func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], items []*ChatItem) (*adk.GenInputResult[*ChatItem], error) {
-	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], items []*ChatItem) (*adk.GenInputResult[*ChatItem], error) {
+func (s *Server) makeGenInput(sess *mem.Session, sessionID string) func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], items []*ChatItem) (*adk.GenInputResult[*ChatItem, *schema.Message], error) {
+	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], items []*ChatItem) (*adk.GenInputResult[*ChatItem, *schema.Message], error) {
 		// Find the first item with a query.
 		var consumed []*ChatItem
 		var remaining []*ChatItem
@@ -507,7 +555,7 @@ func (s *Server) makeGenInput(sess *mem.Session, sessionID string) func(ctx cont
 		if queryItem == nil {
 			// No query items — stop the loop.
 			loop.Stop(adk.WithStopCause("no query items"))
-			return &adk.GenInputResult[*ChatItem]{
+			return &adk.GenInputResult[*ChatItem, *schema.Message]{
 				Input:     &adk.AgentInput{Messages: []adk.Message{schema.UserMessage("done")}},
 				Remaining: items,
 			}, nil
@@ -526,7 +574,7 @@ func (s *Server) makeGenInput(sess *mem.Session, sessionID string) func(ctx cont
 
 		log.Printf("[genInput] session=%s query=%q messages=%d", sessionID, queryItem.Query, len(runMessages))
 
-		return &adk.GenInputResult[*ChatItem]{
+		return &adk.GenInputResult[*ChatItem, *schema.Message]{
 			Input: &adk.AgentInput{
 				Messages:        runMessages,
 				EnableStreaming: true,
@@ -538,16 +586,16 @@ func (s *Server) makeGenInput(sess *mem.Session, sessionID string) func(ctx cont
 }
 
 // makePrepareAgent returns the PrepareAgent callback — returns the same agent.
-func (s *Server) makePrepareAgent() func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], consumed []*ChatItem) (adk.Agent, error) {
-	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], consumed []*ChatItem) (adk.Agent, error) {
+func (s *Server) makePrepareAgent() func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], consumed []*ChatItem) (adk.Agent, error) {
+	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], consumed []*ChatItem) (adk.Agent, error) {
 		return s.cfg.Agent, nil
 	}
 }
 
 // makeOnAgentEvents returns the OnAgentEvents callback — the bridge between
 // the TurnLoop and the HTTP handler.
-func (s *Server) makeOnAgentEvents(sess *mem.Session, sessionID string) func(ctx context.Context, tc *adk.TurnContext[*ChatItem], events *adk.AsyncIterator[*adk.AgentEvent]) error {
-	return func(ctx context.Context, tc *adk.TurnContext[*ChatItem], events *adk.AsyncIterator[*adk.AgentEvent]) error {
+func (s *Server) makeOnAgentEvents(sess *mem.Session, sessionID string) func(ctx context.Context, tc *adk.TurnContext[*ChatItem, *schema.Message], events *adk.AsyncIterator[*adk.AgentEvent]) error {
+	return func(ctx context.Context, tc *adk.TurnContext[*ChatItem, *schema.Message], events *adk.AsyncIterator[*adk.AgentEvent]) error {
 		ts := s.getTurnState(sessionID)
 
 		history := sess.GetMessages()
@@ -584,8 +632,8 @@ func (s *Server) makeOnAgentEvents(sess *mem.Session, sessionID string) func(ctx
 }
 
 // makeGenResume returns the GenResume callback for interrupt/resume.
-func (s *Server) makeGenResume() func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], canceledItems, unhandledItems, newItems []*ChatItem) (*adk.GenResumeResult[*ChatItem], error) {
-	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], canceledItems, unhandledItems, newItems []*ChatItem) (*adk.GenResumeResult[*ChatItem], error) {
+func (s *Server) makeGenResume() func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], canceledItems, unhandledItems, newItems []*ChatItem) (*adk.GenResumeResult[*ChatItem, *schema.Message], error) {
+	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], canceledItems, unhandledItems, newItems []*ChatItem) (*adk.GenResumeResult[*ChatItem, *schema.Message], error) {
 		// Find the approval item in newItems.
 		var approvalItem *ChatItem
 		for _, item := range newItems {
@@ -598,7 +646,7 @@ func (s *Server) makeGenResume() func(ctx context.Context, loop *adk.TurnLoop[*C
 			return nil, errors.New("no approval item found for resume")
 		}
 
-		return &adk.GenResumeResult[*ChatItem]{
+		return &adk.GenResumeResult[*ChatItem, *schema.Message]{
 			ResumeParams: &adk.ResumeParams{
 				Targets: map[string]any{approvalItem.InterruptID: approvalItem.ApprovalResult},
 			},

--- a/quickstart/chatwitheino/server/server.go
+++ b/quickstart/chatwitheino/server/server.go
@@ -20,11 +20,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cloudwego/hertz/pkg/app"
@@ -36,29 +38,99 @@ import (
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/schema"
 
-	"github.com/cloudwego/eino-examples/adk/common/tool"
+	commontool "github.com/cloudwego/eino-examples/adk/common/tool"
 	"github.com/cloudwego/eino-examples/quickstart/chatwitheino/a2ui"
 	"github.com/cloudwego/eino-examples/quickstart/chatwitheino/mem"
 )
 
+func init() {
+	schema.RegisterName[ChatItem]("chatwitheino_chat_item")
+	schema.RegisterName[commontool.ApprovalResult]("chatwitheino_approval_result")
+}
+
+// ChatItem is the item type for TurnLoop. Each user query or approval decision
+// is pushed as a ChatItem.
+type ChatItem struct {
+	Query          string                     // user message text (empty for approval items)
+	ApprovalResult *commontool.ApprovalResult // non-nil when this item carries an approval decision
+	InterruptID    string                     // which interrupt this approval resolves
+}
+
+// errInterrupted is returned by OnAgentEvents when the agent is interrupted
+// for approval. The TurnLoop exits with this as ExitReason.
+var errInterrupted = errors.New("agent interrupted for approval")
+
 // Config holds all dependencies for the HTTP server.
 type Config struct {
-	Runner       *adk.Runner
-	Store        *mem.Store
-	WorkspaceDir string
-	ProjectRoot  string // root of the codebase the agent can explore
-	ExamplesDir  string // root of the eino-examples repo (for example searches)
-	Port         string
+	Agent           adk.Agent
+	CheckPointStore adk.CheckPointStore
+	Store           *mem.Store
+	WorkspaceDir    string
+	ProjectRoot     string // root of the codebase the agent can explore
+	ExamplesDir     string // root of the eino-examples repo (for example searches)
+	Port            string
 }
 
 // Server wraps a Hertz HTTP server with the chat-with-doc routes.
 type Server struct {
-	cfg Config
+	cfg        Config
+	turnStates sync.Map // sessionID → *sessionTurnState
 }
 
 // New creates a Server from the given config.
 func New(cfg Config) *Server {
 	return &Server{cfg: cfg}
+}
+
+// iterEnvelope carries the event iterator from OnAgentEvents to the HTTP handler.
+// The done channel is included so the handler always sends results back to the
+// correct OnAgentEvents invocation, even if a preempt replaces the session channels.
+type iterEnvelope struct {
+	events  *adk.AsyncIterator[*adk.AgentEvent]
+	history []*schema.Message
+	done    chan iterResult
+}
+
+// iterResult carries the outcome from the HTTP handler back to OnAgentEvents.
+type iterResult struct {
+	lastContent   string
+	intermediates []*schema.Message // tool call + tool result messages to persist
+	interruptID   string
+	msgIdx        int
+	err           error
+}
+
+// sessionTurnState holds the TurnLoop and event bridge channels for a session.
+type sessionTurnState struct {
+	mu        sync.Mutex
+	loop      *adk.TurnLoop[*ChatItem]
+	iterReady chan iterEnvelope // OnAgentEvents → HTTP handler
+	iterDone  chan iterResult   // HTTP handler → OnAgentEvents
+}
+
+func (s *Server) getTurnState(sessionID string) *sessionTurnState {
+	val, _ := s.turnStates.LoadOrStore(sessionID, &sessionTurnState{})
+	return val.(*sessionTurnState)
+}
+
+// startLoopCleanup spawns a goroutine that waits for the loop to exit
+// (e.g. due to an error or all items consumed) and nils out ts.loop so
+// the next handleChat creates a fresh loop instead of trying to preempt
+// a dead one.
+func (s *Server) startLoopCleanup(ts *sessionTurnState, loop *adk.TurnLoop[*ChatItem], sessionID string) {
+	go func() {
+		result := loop.Wait()
+		ts.mu.Lock()
+		if ts.loop == loop {
+			ts.loop = nil
+		}
+		ts.mu.Unlock()
+		if result.ExitReason != nil {
+			log.Printf("[loop] session=%s exited with error: %v", sessionID, result.ExitReason)
+		} else {
+			log.Printf("[loop] session=%s exited cleanly", sessionID)
+		}
+	}()
 }
 
 // Spin starts the HTTP server (blocking).
@@ -97,10 +169,20 @@ func (s *Server) Spin() {
 
 	h.DELETE("/sessions/:id", func(ctx context.Context, c *app.RequestContext) {
 		id := c.Param("id")
+		// Stop any running loop for this session.
+		ts := s.getTurnState(id)
+		ts.mu.Lock()
+		if ts.loop != nil {
+			ts.loop.Stop(adk.WithImmediate())
+			ts.loop = nil
+		}
+		ts.mu.Unlock()
+
 		if err := s.cfg.Store.Delete(id); err != nil {
 			c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
+		s.turnStates.Delete(id)
 		c.Status(consts.StatusNoContent)
 	})
 
@@ -114,6 +196,10 @@ func (s *Server) Spin() {
 
 	h.POST("/sessions/:id/approve", func(ctx context.Context, c *app.RequestContext) {
 		s.handleApprove(ctx, c)
+	})
+
+	h.POST("/sessions/:id/abort", func(ctx context.Context, c *app.RequestContext) {
+		s.handleAbort(ctx, c)
 	})
 
 	h.POST("/sessions/:id/docs", func(ctx context.Context, c *app.RequestContext) {
@@ -147,6 +233,8 @@ func (s *Server) handleRender(_ context.Context, c *app.RequestContext) {
 	c.Data(consts.StatusOK, "application/x-ndjson", buf.Bytes())
 }
 
+// handleChat handles a new chat message. It creates or reuses a TurnLoop for the session.
+// If a loop is already running (busy), it pushes with preempt to cancel the current turn.
 func (s *Server) handleChat(ctx context.Context, c *app.RequestContext) {
 	id := c.Param("id")
 
@@ -165,25 +253,60 @@ func (s *Server) handleChat(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	userMsg := schema.UserMessage(req.Message)
-	if appendErr := sess.Append(userMsg); appendErr != nil {
-		log.Printf("warn: failed to persist user message: %v", appendErr)
+	item := &ChatItem{Query: req.Message}
+
+	ts := s.getTurnState(id)
+	ts.mu.Lock()
+	if ts.loop != nil {
+		// Loop exists — try to push with preempt (AfterToolCalls).
+		loop := ts.loop
+		log.Printf("[chat] session=%s preempting current turn", id)
+		ts.iterReady = make(chan iterEnvelope, 1)
+		ts.iterDone = make(chan iterResult, 1)
+		ts.mu.Unlock()
+		ok, _ := loop.Push(item, adk.WithPreempt[*ChatItem](adk.AfterToolCalls))
+		if !ok {
+			// Loop already stopped (e.g. error on previous turn) — create new one.
+			log.Printf("[chat] session=%s loop was dead, creating new loop", id)
+			ts.mu.Lock()
+			loop = s.newLoop(sess, id, false)
+			ts.loop = loop
+			ts.iterReady = make(chan iterEnvelope, 1)
+			ts.iterDone = make(chan iterResult, 1)
+			ts.mu.Unlock()
+			loop.Push(item)
+			loop.Run(context.Background())
+			s.startLoopCleanup(ts, loop, id)
+		}
+	} else {
+		// No loop — create a new one.
+		loop := s.newLoop(sess, id, false)
+		ts.loop = loop
+		ts.iterReady = make(chan iterEnvelope, 1)
+		ts.iterDone = make(chan iterResult, 1)
+		ts.mu.Unlock()
+		loop.Push(item)
+		loop.Run(context.Background())
+		s.startLoopCleanup(ts, loop, id)
 	}
 
-	// history is rendered in the UI; runMessages adds workspace context for the agent.
-	history := sess.GetMessages()
-	runMessages := s.buildRunMessages(id, history)
+	// User message is persisted in GenInput (not here) to guarantee correct
+	// session history ordering: the preempted turn's intermediates are persisted
+	// by OnAgentEvents before GenInput fires for the new turn.
 
-	log.Printf("[chat] session=%s running agent with %d messages (%d history + %d context)",
-		id, len(runMessages), len(history), len(runMessages)-len(history))
+	// Wait for OnAgentEvents to send us the iterator.
+	var envelope iterEnvelope
+	select {
+	case envelope = <-ts.iterReady:
+	case <-time.After(60 * time.Second):
+		c.JSON(consts.StatusGatewayTimeout, map[string]string{"error": "agent did not start in time"})
+		return
+	}
 
-	iter := s.cfg.Runner.Run(ctx, runMessages, adk.WithCheckPointID(id))
-
+	// Open SSE stream.
 	stream := sse.NewStream(c)
 	defer func() { _ = c.Flush() }()
 
-	// Send a keep-alive ping every 5 s so the SSE connection isn't dropped
-	// by Hertz or browser timeouts while the agent is processing tool results.
 	kaStop := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
@@ -194,28 +317,294 @@ func (s *Server) handleChat(ctx context.Context, c *app.RequestContext) {
 				return
 			case <-ticker.C:
 				_ = stream.Publish(&sse.Event{Data: []byte{}})
-				log.Printf("[chat] session=%s keep-alive ping sent", id)
 			}
 		}
 	}()
 
-	lastContent, interruptID, finalMsgIdx, streamErr := a2ui.StreamToWriter(&sseLineWriter{stream: stream}, id, history, iter)
+	lastContent, intermediates, interruptID, finalMsgIdx, streamErr := a2ui.StreamToWriter(
+		&sseLineWriter{stream: stream}, id, envelope.history, envelope.events,
+	)
 	close(kaStop)
+
+	// Send result back to the SAME OnAgentEvents that sent us this envelope.
+	envelope.done <- iterResult{
+		lastContent:   lastContent,
+		intermediates: intermediates,
+		interruptID:   interruptID,
+		msgIdx:        finalMsgIdx,
+		err:           streamErr,
+	}
+
 	if streamErr != nil {
 		log.Printf("[chat] session=%s stream error: %v", id, streamErr)
 	} else if interruptID != "" {
 		log.Printf("[chat] session=%s interrupted: id=%s", id, interruptID)
-		sess.SetPendingInterruptID(interruptID)
-		sess.SetMsgIdx(finalMsgIdx)
 	} else {
 		log.Printf("[chat] session=%s done, response=%d chars", id, len(lastContent))
 	}
+}
 
-	if lastContent != "" {
-		assistantMsg := schema.AssistantMessage(lastContent, nil)
-		if appendErr := sess.Append(assistantMsg); appendErr != nil {
-			log.Printf("warn: failed to persist assistant message: %v", appendErr)
+// handleApprove resumes an interrupted agent run with the user's approval decision.
+// Creates a new TurnLoop with checkpoint/resume to continue from the interrupt.
+func (s *Server) handleApprove(ctx context.Context, c *app.RequestContext) {
+	id := c.Param("id")
+
+	sess, err := s.cfg.Store.GetOrCreate(id)
+	if err != nil {
+		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	interruptID := sess.GetPendingInterruptID()
+	if interruptID == "" {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": "no pending interrupt for this session"})
+		return
+	}
+
+	body, _ := c.Body()
+	var req approveRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		c.JSON(consts.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	var reason *string
+	if req.Reason != "" {
+		reason = &req.Reason
+	}
+	result := &commontool.ApprovalResult{Approved: req.Approved, DisapproveReason: reason}
+
+	// Clear the pending interrupt so a double-approve returns 400.
+	sess.SetPendingInterruptID("")
+
+	log.Printf("[approve] session=%s interruptID=%s approved=%v", id, interruptID, req.Approved)
+
+	// Create a new loop with checkpoint resume.
+	ts := s.getTurnState(id)
+	ts.mu.Lock()
+	// Clear any old loop.
+	if ts.loop != nil {
+		ts.loop.Stop(adk.WithImmediate())
+	}
+	loop := s.newLoop(sess, id, true)
+	ts.loop = loop
+	ts.iterReady = make(chan iterEnvelope, 1)
+	ts.iterDone = make(chan iterResult, 1)
+	ts.mu.Unlock()
+
+	// Push the approval item before starting.
+	loop.Push(&ChatItem{
+		ApprovalResult: result,
+		InterruptID:    interruptID,
+	})
+	loop.Run(context.Background())
+	s.startLoopCleanup(ts, loop, id)
+
+	// Wait for OnAgentEvents to send us the iterator.
+	var envelope iterEnvelope
+	select {
+	case envelope = <-ts.iterReady:
+	case <-time.After(60 * time.Second):
+		c.JSON(consts.StatusGatewayTimeout, map[string]string{"error": "agent did not start in time"})
+		return
+	}
+	_ = envelope.history // not used for StreamContinue
+
+	stream := sse.NewStream(c)
+	defer func() { _ = c.Flush() }()
+
+	kaStop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-kaStop:
+				return
+			case <-ticker.C:
+				_ = stream.Publish(&sse.Event{Data: []byte{}})
+			}
 		}
+	}()
+
+	lastContent, newInterruptID, finalMsgIdx, streamErr := a2ui.StreamContinue(
+		&sseLineWriter{stream: stream}, id, sess.GetMsgIdx(), envelope.events,
+	)
+	close(kaStop)
+
+	// Send result back to the SAME OnAgentEvents that sent us this envelope.
+	envelope.done <- iterResult{
+		lastContent: lastContent,
+		interruptID: newInterruptID,
+		msgIdx:      finalMsgIdx,
+		err:         streamErr,
+	}
+
+	if streamErr != nil {
+		log.Printf("[approve] session=%s stream error: %v", id, streamErr)
+	} else if newInterruptID != "" {
+		log.Printf("[approve] session=%s re-interrupted: id=%s", id, newInterruptID)
+	} else {
+		log.Printf("[approve] session=%s done, response=%d chars", id, len(lastContent))
+	}
+}
+
+// handleAbort immediately stops the current TurnLoop for a session.
+func (s *Server) handleAbort(_ context.Context, c *app.RequestContext) {
+	id := c.Param("id")
+
+	ts := s.getTurnState(id)
+	ts.mu.Lock()
+	loop := ts.loop
+	ts.loop = nil
+	ts.mu.Unlock()
+
+	if loop == nil {
+		c.JSON(consts.StatusOK, map[string]string{"status": "no active loop"})
+		return
+	}
+
+	log.Printf("[abort] session=%s stopping loop immediately", id)
+	loop.Stop(adk.WithImmediate())
+	loop.Wait()
+	log.Printf("[abort] session=%s loop stopped", id)
+
+	c.JSON(consts.StatusOK, map[string]string{"status": "aborted"})
+}
+
+// newLoop creates a new TurnLoop for the session. If withResume is true,
+// the loop is configured with a checkpoint store and GenResume for interrupt resume.
+func (s *Server) newLoop(sess *mem.Session, sessionID string, withResume bool) *adk.TurnLoop[*ChatItem] {
+	cfg := adk.TurnLoopConfig[*ChatItem]{
+		GenInput:      s.makeGenInput(sess, sessionID),
+		PrepareAgent:  s.makePrepareAgent(),
+		OnAgentEvents: s.makeOnAgentEvents(sess, sessionID),
+	}
+	if withResume {
+		cfg.Store = s.cfg.CheckPointStore
+		cfg.CheckpointID = sessionID
+		cfg.GenResume = s.makeGenResume()
+	}
+	return adk.NewTurnLoop(cfg)
+}
+
+// makeGenInput returns the GenInput callback. It builds agent messages from
+// session history + workspace context.
+func (s *Server) makeGenInput(sess *mem.Session, sessionID string) func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], items []*ChatItem) (*adk.GenInputResult[*ChatItem], error) {
+	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], items []*ChatItem) (*adk.GenInputResult[*ChatItem], error) {
+		// Find the first item with a query.
+		var consumed []*ChatItem
+		var remaining []*ChatItem
+		var queryItem *ChatItem
+		for _, item := range items {
+			if queryItem == nil && item.Query != "" {
+				queryItem = item
+				consumed = append(consumed, item)
+			} else {
+				remaining = append(remaining, item)
+			}
+		}
+		if queryItem == nil {
+			// No query items — stop the loop.
+			loop.Stop(adk.WithStopCause("no query items"))
+			return &adk.GenInputResult[*ChatItem]{
+				Input:     &adk.AgentInput{Messages: []adk.Message{schema.UserMessage("done")}},
+				Remaining: items,
+			}, nil
+		}
+
+		// Persist the user message NOW — GenInput fires only after any previous
+		// turn's OnAgentEvents has finished persisting its intermediates, so the
+		// session history order is guaranteed correct.
+		userMsg := schema.UserMessage(queryItem.Query)
+		if appendErr := sess.Append(userMsg); appendErr != nil {
+			log.Printf("warn: failed to persist user message: %v", appendErr)
+		}
+
+		history := sess.GetMessages()
+		runMessages := s.buildRunMessages(sessionID, history)
+
+		log.Printf("[genInput] session=%s query=%q messages=%d", sessionID, queryItem.Query, len(runMessages))
+
+		return &adk.GenInputResult[*ChatItem]{
+			Input: &adk.AgentInput{
+				Messages:        runMessages,
+				EnableStreaming: true,
+			},
+			Consumed:  consumed,
+			Remaining: remaining,
+		}, nil
+	}
+}
+
+// makePrepareAgent returns the PrepareAgent callback — returns the same agent.
+func (s *Server) makePrepareAgent() func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], consumed []*ChatItem) (adk.Agent, error) {
+	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], consumed []*ChatItem) (adk.Agent, error) {
+		return s.cfg.Agent, nil
+	}
+}
+
+// makeOnAgentEvents returns the OnAgentEvents callback — the bridge between
+// the TurnLoop and the HTTP handler.
+func (s *Server) makeOnAgentEvents(sess *mem.Session, sessionID string) func(ctx context.Context, tc *adk.TurnContext[*ChatItem], events *adk.AsyncIterator[*adk.AgentEvent]) error {
+	return func(ctx context.Context, tc *adk.TurnContext[*ChatItem], events *adk.AsyncIterator[*adk.AgentEvent]) error {
+		ts := s.getTurnState(sessionID)
+
+		history := sess.GetMessages()
+
+		// Snapshot bridge channels under lock to avoid races with handleChat
+		// which may recreate them for a preempt.
+		ts.mu.Lock()
+		ready := ts.iterReady
+		done := ts.iterDone
+		ts.mu.Unlock()
+
+		// Send the iterator to the HTTP handler. Include the done channel
+		// so the handler replies to THIS invocation, not a future one.
+		ready <- iterEnvelope{events: events, history: history, done: done}
+
+		// Wait for the HTTP handler to finish draining.
+		result := <-done
+
+		// Persist all intermediate messages (assistant text+tool calls, tool results).
+		// The intermediates already include the final assistant text message if any,
+		// so we don't need to persist lastContent separately.
+		for _, msg := range result.intermediates {
+			if appendErr := sess.Append(msg); appendErr != nil {
+				log.Printf("warn: failed to persist intermediate message: %v", appendErr)
+			}
+		}
+		if result.interruptID != "" {
+			sess.SetPendingInterruptID(result.interruptID)
+			sess.SetMsgIdx(result.msgIdx)
+			return errInterrupted
+		}
+		return result.err
+	}
+}
+
+// makeGenResume returns the GenResume callback for interrupt/resume.
+func (s *Server) makeGenResume() func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], canceledItems, unhandledItems, newItems []*ChatItem) (*adk.GenResumeResult[*ChatItem], error) {
+	return func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], canceledItems, unhandledItems, newItems []*ChatItem) (*adk.GenResumeResult[*ChatItem], error) {
+		// Find the approval item in newItems.
+		var approvalItem *ChatItem
+		for _, item := range newItems {
+			if item.ApprovalResult != nil {
+				approvalItem = item
+				break
+			}
+		}
+		if approvalItem == nil {
+			return nil, errors.New("no approval item found for resume")
+		}
+
+		return &adk.GenResumeResult[*ChatItem]{
+			ResumeParams: &adk.ResumeParams{
+				Targets: map[string]any{approvalItem.InterruptID: approvalItem.ApprovalResult},
+			},
+			Consumed:  canceledItems,
+			Remaining: unhandledItems,
+		}, nil
 	}
 }
 
@@ -321,87 +710,6 @@ func (s *Server) handleUpload(ctx context.Context, c *app.RequestContext) {
 		"name": fileHeader.Filename,
 		"path": dst,
 	})
-}
-
-// handleApprove resumes an interrupted agent run with the user's approval decision.
-// The agent must have been interrupted earlier in this session (via the approval
-// middleware). The session ID is used as the checkpoint ID.
-func (s *Server) handleApprove(ctx context.Context, c *app.RequestContext) {
-	id := c.Param("id")
-
-	sess, err := s.cfg.Store.GetOrCreate(id)
-	if err != nil {
-		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-
-	interruptID := sess.GetPendingInterruptID()
-	if interruptID == "" {
-		c.JSON(consts.StatusBadRequest, map[string]string{"error": "no pending interrupt for this session"})
-		return
-	}
-
-	body, _ := c.Body()
-	var req approveRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		c.JSON(consts.StatusBadRequest, map[string]string{"error": "invalid request body"})
-		return
-	}
-
-	var reason *string
-	if req.Reason != "" {
-		reason = &req.Reason
-	}
-	result := &tool.ApprovalResult{Approved: req.Approved, DisapproveReason: reason}
-
-	iter, err := s.cfg.Runner.ResumeWithParams(ctx, id, &adk.ResumeParams{
-		Targets: map[string]any{interruptID: result},
-	})
-	if err != nil {
-		c.JSON(consts.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-
-	// Clear the pending interrupt immediately so a double-approve returns 400.
-	sess.SetPendingInterruptID("")
-
-	log.Printf("[approve] session=%s interruptID=%s approved=%v", id, interruptID, req.Approved)
-
-	stream := sse.NewStream(c)
-	defer func() { _ = c.Flush() }()
-
-	kaStop := make(chan struct{})
-	go func() {
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-kaStop:
-				return
-			case <-ticker.C:
-				_ = stream.Publish(&sse.Event{Data: []byte{}})
-			}
-		}
-	}()
-
-	lastContent, newInterruptID, finalMsgIdx, streamErr := a2ui.StreamContinue(&sseLineWriter{stream: stream}, id, sess.GetMsgIdx(), iter)
-	close(kaStop)
-	if streamErr != nil {
-		log.Printf("[approve] session=%s stream error: %v", id, streamErr)
-	} else if newInterruptID != "" {
-		log.Printf("[approve] session=%s re-interrupted: id=%s", id, newInterruptID)
-		sess.SetPendingInterruptID(newInterruptID)
-		sess.SetMsgIdx(finalMsgIdx)
-	} else {
-		log.Printf("[approve] session=%s done, response=%d chars", id, len(lastContent))
-	}
-
-	if lastContent != "" {
-		assistantMsg := schema.AssistantMessage(lastContent, nil)
-		if appendErr := sess.Append(assistantMsg); appendErr != nil {
-			log.Printf("warn: failed to persist assistant message: %v", appendErr)
-		}
-	}
 }
 
 // sseLineWriter implements io.Writer, buffering until a newline is found,

--- a/quickstart/chatwitheino/server/server.go
+++ b/quickstart/chatwitheino/server/server.go
@@ -609,10 +609,21 @@ func (s *Server) makeOnAgentEvents(sess *mem.Session, sessionID string) func(ctx
 
 		// Send the iterator to the HTTP handler. Include the done channel
 		// so the handler replies to THIS invocation, not a future one.
-		ready <- iterEnvelope{events: events, history: history, done: done}
+		select {
+		case ready <- iterEnvelope{events: events, history: history, done: done}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 
-		// Wait for the HTTP handler to finish draining.
-		result := <-done
+		// Wait for the HTTP handler to finish draining. Also select on ctx.Done
+		// to avoid hanging when a preempt supersedes the handler — in that case
+		// the old handler bails via handlerDone and nobody sends to our done channel.
+		var result iterResult
+		select {
+		case result = <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 
 		// Persist all intermediate messages (assistant text+tool calls, tool results).
 		// The intermediates already include the final assistant text message if any,

--- a/quickstart/chatwitheino/server/server_test.go
+++ b/quickstart/chatwitheino/server/server_test.go
@@ -42,7 +42,7 @@ type mockAgent struct {
 }
 
 func (m *mockAgent) Name(context.Context) string        { return m.name }
-func (m *mockAgent) Description(context.Context) string  { return "mock" }
+func (m *mockAgent) Description(context.Context) string { return "mock" }
 func (m *mockAgent) Run(ctx context.Context, input *adk.AgentInput, _ ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
 	iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
 	go m.onRun(ctx, input, gen)
@@ -314,7 +314,7 @@ func TestPreemptQueuesNewItem(t *testing.T) {
 
 	// Wrap the GenInput callback to track seen queries.
 	origGenInput := srv.makeGenInput(sess, sessionID)
-	wrappedGenInput := func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], items []*ChatItem) (*adk.GenInputResult[*ChatItem], error) {
+	wrappedGenInput := func(ctx context.Context, loop *adk.TurnLoop[*ChatItem, *schema.Message], items []*ChatItem) (*adk.GenInputResult[*ChatItem, *schema.Message], error) {
 		for _, item := range items {
 			if item.Query != "" {
 				mu.Lock()
@@ -326,7 +326,7 @@ func TestPreemptQueuesNewItem(t *testing.T) {
 	}
 
 	// Create loop with wrapped GenInput.
-	cfg := adk.TurnLoopConfig[*ChatItem]{
+	cfg := adk.TurnLoopConfig[*ChatItem, *schema.Message]{
 		GenInput:      wrappedGenInput,
 		PrepareAgent:  srv.makePrepareAgent(),
 		OnAgentEvents: srv.makeOnAgentEvents(sess, sessionID),
@@ -374,7 +374,7 @@ func TestPreemptQueuesNewItem(t *testing.T) {
 	ts.iterDone = make(chan iterResult, 1)
 	ts.mu.Unlock()
 
-	loop.Push(&ChatItem{Query: "second"}, adk.WithPreempt[*ChatItem](adk.AfterToolCalls))
+	loop.Push(&ChatItem{Query: "second"}, adk.WithPreempt[*ChatItem, *schema.Message](adk.AfterToolCalls))
 
 	// Consume second turn.
 	select {
@@ -427,9 +427,9 @@ func TestGenResumeFindsApprovalItem(t *testing.T) {
 	}
 
 	result, err := genResume(context.Background(), nil,
-		[]*ChatItem{{Query: "canceled"}},     // canceledItems
-		[]*ChatItem{},                         // unhandledItems
-		[]*ChatItem{approvalItem},             // newItems
+		[]*ChatItem{{Query: "canceled"}}, // canceledItems
+		[]*ChatItem{},                    // unhandledItems
+		[]*ChatItem{approvalItem},        // newItems
 	)
 	if err != nil {
 		t.Fatalf("genResume error: %v", err)

--- a/quickstart/chatwitheino/server/server_test.go
+++ b/quickstart/chatwitheino/server/server_test.go
@@ -271,7 +271,7 @@ func TestAbortStopsLoop(t *testing.T) {
 					break
 				}
 			}
-			ts.iterDone <- iterResult{err: context.Canceled}
+			envelope.done <- iterResult{err: context.Canceled}
 		}()
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for iterReady")
@@ -356,7 +356,7 @@ func TestPreemptQueuesNewItem(t *testing.T) {
 				break
 			}
 		}
-		ts.iterDone <- iterResult{lastContent: "reply"}
+		envelope.done <- iterResult{lastContent: "reply"}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout on first turn")
 	}
@@ -385,7 +385,7 @@ func TestPreemptQueuesNewItem(t *testing.T) {
 				break
 			}
 		}
-		ts.iterDone <- iterResult{lastContent: "reply"}
+		envelope.done <- iterResult{lastContent: "reply"}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout on second turn")
 	}

--- a/quickstart/chatwitheino/server/server_test.go
+++ b/quickstart/chatwitheino/server/server_test.go
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/schema"
+
+	adkstore "github.com/cloudwego/eino-examples/adk/common/store"
+	commontool "github.com/cloudwego/eino-examples/adk/common/tool"
+	"github.com/cloudwego/eino-examples/quickstart/chatwitheino/mem"
+)
+
+// ---------------------------------------------------------------------------
+// mock agent — emits configurable events then exits
+// ---------------------------------------------------------------------------
+
+type mockAgent struct {
+	name string
+	// onRun is called for each Run(); must send events to gen and Close it.
+	onRun func(ctx context.Context, input *adk.AgentInput, gen *adk.AsyncGenerator[*adk.AgentEvent])
+}
+
+func (m *mockAgent) Name(context.Context) string        { return m.name }
+func (m *mockAgent) Description(context.Context) string  { return "mock" }
+func (m *mockAgent) Run(ctx context.Context, input *adk.AgentInput, _ ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
+	iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+	go m.onRun(ctx, input, gen)
+	return iter
+}
+
+// simpleReplyAgent returns a mock that emits a single text message and exits.
+func simpleReplyAgent(reply string) *mockAgent {
+	return &mockAgent{
+		name: "test-agent",
+		onRun: func(ctx context.Context, _ *adk.AgentInput, gen *adk.AsyncGenerator[*adk.AgentEvent]) {
+			defer gen.Close()
+			gen.Send(&adk.AgentEvent{
+				Output: &adk.AgentOutput{
+					MessageOutput: &adk.MessageVariant{
+						Message: schema.AssistantMessage(reply, nil),
+						Role:    schema.Assistant,
+					},
+				},
+			})
+			gen.Send(&adk.AgentEvent{Action: adk.NewExitAction()})
+		},
+	}
+}
+
+// slowAgent returns a mock that delays before replying, respecting context cancellation.
+func slowAgent(delay time.Duration, reply string) *mockAgent {
+	return &mockAgent{
+		name: "slow-agent",
+		onRun: func(ctx context.Context, _ *adk.AgentInput, gen *adk.AsyncGenerator[*adk.AgentEvent]) {
+			defer gen.Close()
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				gen.Send(&adk.AgentEvent{Err: ctx.Err()})
+				return
+			}
+			gen.Send(&adk.AgentEvent{
+				Output: &adk.AgentOutput{
+					MessageOutput: &adk.MessageVariant{
+						Message: schema.AssistantMessage(reply, nil),
+						Role:    schema.Assistant,
+					},
+				},
+			})
+			gen.Send(&adk.AgentEvent{Action: adk.NewExitAction()})
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helper: setup test server + HTTP client
+// ---------------------------------------------------------------------------
+
+func newTestServer(t *testing.T, agent adk.Agent) (*Server, string, func()) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	store, err := mem.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("mem.NewStore: %v", err)
+	}
+
+	srv := New(Config{
+		Agent:           agent,
+		CheckPointStore: adkstore.NewInMemoryStore(),
+		Store:           store,
+		WorkspaceDir:    t.TempDir(),
+		ProjectRoot:     t.TempDir(),
+		ExamplesDir:     t.TempDir(),
+		Port:            "0", // unused — we test via the handler functions directly
+	})
+
+	return srv, tmpDir, func() {}
+}
+
+// createSession creates a session via the Store directly.
+func createSession(t *testing.T, srv *Server) string {
+	t.Helper()
+	sess, err := srv.cfg.Store.GetOrCreate("test-" + time.Now().Format("150405.000"))
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return sess.ID
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestNewLoopCreation(t *testing.T) {
+	agent := simpleReplyAgent("hello from agent")
+	srv, _, cleanup := newTestServer(t, agent)
+	defer cleanup()
+
+	sessionID := createSession(t, srv)
+	sess, _ := srv.cfg.Store.GetOrCreate(sessionID)
+
+	// Create a loop.
+	loop := srv.newLoop(sess, sessionID, false)
+	if loop == nil {
+		t.Fatal("newLoop returned nil")
+	}
+
+	// Verify turn state is tracked.
+	ts := srv.getTurnState(sessionID)
+	if ts == nil {
+		t.Fatal("getTurnState returned nil")
+	}
+}
+
+func TestChatNormalFlow(t *testing.T) {
+	agent := simpleReplyAgent("test response")
+	srv, _, cleanup := newTestServer(t, agent)
+	defer cleanup()
+
+	sessionID := createSession(t, srv)
+	sess, _ := srv.cfg.Store.GetOrCreate(sessionID)
+
+	// Simulate handleChat: create loop, push item, run, consume events.
+	ts := srv.getTurnState(sessionID)
+	ts.mu.Lock()
+	loop := srv.newLoop(sess, sessionID, false)
+	ts.loop = loop
+	ts.iterReady = make(chan iterEnvelope, 1)
+	ts.iterDone = make(chan iterResult, 1)
+	ts.mu.Unlock()
+
+	item := &ChatItem{Query: "hello"}
+	if err := sess.Append(schema.UserMessage("hello")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	loop.Push(item)
+	loop.Run(context.Background())
+
+	// Wait for the iterator.
+	var envelope iterEnvelope
+	select {
+	case envelope = <-ts.iterReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for iterReady")
+	}
+
+	// Drain the iterator.
+	var content string
+	for {
+		event, ok := envelope.events.Next()
+		if !ok {
+			break
+		}
+		if event.Output != nil && event.Output.MessageOutput != nil {
+			if m := event.Output.MessageOutput.Message; m != nil && m.Content != "" {
+				content += m.Content
+			}
+		}
+	}
+
+	if content != "test response" {
+		t.Errorf("expected 'test response', got %q", content)
+	}
+
+	// Signal done to OnAgentEvents.
+	envelope.done <- iterResult{
+		lastContent:   content,
+		intermediates: []*schema.Message{schema.AssistantMessage(content, nil)},
+	}
+
+	// Stop the loop — no more items to process.
+	loop.Stop()
+
+	// Wait for loop to exit.
+	result := loop.Wait()
+	if result.ExitReason != nil {
+		// The loop stops when GenInput gets no more query items (next call).
+		// This is expected — it receives empty items and calls Stop.
+		t.Logf("exit reason: %v (expected)", result.ExitReason)
+	}
+
+	// Verify the assistant message was appended to session.
+	messages := sess.GetMessages()
+	found := false
+	for _, m := range messages {
+		if m.Role == schema.Assistant && strings.Contains(m.Content, "test response") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("assistant message not found in session history")
+	}
+}
+
+func TestAbortStopsLoop(t *testing.T) {
+	// Use a slow agent to give us time to abort.
+	// Note: WithImmediate() cancels via the AgentCancelFunc chain in the
+	// TurnLoop's internal Runner. Our simple mock doesn't process RunOptions,
+	// so cancellation relies on the agent's Run completing naturally.
+	agent := slowAgent(500*time.Millisecond, "should not see this")
+	srv, _, cleanup := newTestServer(t, agent)
+	defer cleanup()
+
+	sessionID := createSession(t, srv)
+	sess, _ := srv.cfg.Store.GetOrCreate(sessionID)
+
+	ts := srv.getTurnState(sessionID)
+	ts.mu.Lock()
+	loop := srv.newLoop(sess, sessionID, false)
+	ts.loop = loop
+	ts.iterReady = make(chan iterEnvelope, 1)
+	ts.iterDone = make(chan iterResult, 1)
+	ts.mu.Unlock()
+
+	if err := sess.Append(schema.UserMessage("hello")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	loop.Push(&ChatItem{Query: "hello"})
+	loop.Run(context.Background())
+
+	// Wait for the event iterator to be ready.
+	select {
+	case envelope := <-ts.iterReady:
+		// Start draining events in background (they will error or close due to abort).
+		go func() {
+			for {
+				_, ok := envelope.events.Next()
+				if !ok {
+					break
+				}
+			}
+			ts.iterDone <- iterResult{err: context.Canceled}
+		}()
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for iterReady")
+	}
+
+	// Abort the loop.
+	ts.mu.Lock()
+	ts.loop = nil
+	ts.mu.Unlock()
+	loop.Stop(adk.WithImmediate())
+
+	result := loop.Wait()
+	// Exit reason should be non-nil (canceled).
+	t.Logf("exit reason: %v", result.ExitReason)
+
+	// Verify we can create a new loop after abort.
+	ts.mu.Lock()
+	newLoop := srv.newLoop(sess, sessionID, false)
+	ts.loop = newLoop
+	ts.mu.Unlock()
+	if newLoop == nil {
+		t.Fatal("failed to create new loop after abort")
+	}
+	newLoop.Stop()
+	newLoop.Run(context.Background())
+	newLoop.Wait()
+}
+
+func TestPreemptQueuesNewItem(t *testing.T) {
+	// Track which queries GenInput sees.
+	var queriesSeen []string
+	var mu sync.Mutex
+
+	agent := simpleReplyAgent("reply")
+	srv, _, cleanup := newTestServer(t, agent)
+	defer cleanup()
+
+	sessionID := createSession(t, srv)
+	sess, _ := srv.cfg.Store.GetOrCreate(sessionID)
+
+	// Wrap the GenInput callback to track seen queries.
+	origGenInput := srv.makeGenInput(sess, sessionID)
+	wrappedGenInput := func(ctx context.Context, loop *adk.TurnLoop[*ChatItem], items []*ChatItem) (*adk.GenInputResult[*ChatItem], error) {
+		for _, item := range items {
+			if item.Query != "" {
+				mu.Lock()
+				queriesSeen = append(queriesSeen, item.Query)
+				mu.Unlock()
+			}
+		}
+		return origGenInput(ctx, loop, items)
+	}
+
+	// Create loop with wrapped GenInput.
+	cfg := adk.TurnLoopConfig[*ChatItem]{
+		GenInput:      wrappedGenInput,
+		PrepareAgent:  srv.makePrepareAgent(),
+		OnAgentEvents: srv.makeOnAgentEvents(sess, sessionID),
+	}
+	loop := adk.NewTurnLoop(cfg)
+
+	ts := srv.getTurnState(sessionID)
+	ts.mu.Lock()
+	ts.loop = loop
+	ts.iterReady = make(chan iterEnvelope, 1)
+	ts.iterDone = make(chan iterResult, 1)
+	ts.mu.Unlock()
+
+	// Push first query and run.
+	if err := sess.Append(schema.UserMessage("first")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	loop.Push(&ChatItem{Query: "first"})
+	loop.Run(context.Background())
+
+	// Consume first turn's events.
+	select {
+	case envelope := <-ts.iterReady:
+		for {
+			_, ok := envelope.events.Next()
+			if !ok {
+				break
+			}
+		}
+		ts.iterDone <- iterResult{lastContent: "reply"}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout on first turn")
+	}
+
+	// Now push second query with preempt (loop should still be running,
+	// waiting in GenInput for more items). Since the agent already exited,
+	// the loop is in idle state — Push will queue and GenInput will pick it up.
+	if err := sess.Append(schema.UserMessage("second")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	// Recreate bridge channels for the second turn.
+	ts.mu.Lock()
+	ts.iterReady = make(chan iterEnvelope, 1)
+	ts.iterDone = make(chan iterResult, 1)
+	ts.mu.Unlock()
+
+	loop.Push(&ChatItem{Query: "second"}, adk.WithPreempt[*ChatItem](adk.AfterToolCalls))
+
+	// Consume second turn.
+	select {
+	case envelope := <-ts.iterReady:
+		for {
+			_, ok := envelope.events.Next()
+			if !ok {
+				break
+			}
+		}
+		ts.iterDone <- iterResult{lastContent: "reply"}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout on second turn")
+	}
+
+	// Stop the loop.
+	loop.Stop()
+	loop.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(queriesSeen) < 2 {
+		t.Errorf("expected at least 2 queries seen, got %d: %v", len(queriesSeen), queriesSeen)
+	}
+	foundFirst := false
+	foundSecond := false
+	for _, q := range queriesSeen {
+		if q == "first" {
+			foundFirst = true
+		}
+		if q == "second" {
+			foundSecond = true
+		}
+	}
+	if !foundFirst || !foundSecond {
+		t.Errorf("expected both 'first' and 'second' in queriesSeen, got %v", queriesSeen)
+	}
+}
+
+func TestGenResumeFindsApprovalItem(t *testing.T) {
+	agent := simpleReplyAgent("irrelevant")
+	srv, _, cleanup := newTestServer(t, agent)
+	defer cleanup()
+
+	genResume := srv.makeGenResume()
+
+	approvalItem := &ChatItem{
+		InterruptID:    "interrupt-123",
+		ApprovalResult: &commontool.ApprovalResult{Approved: true},
+	}
+
+	result, err := genResume(context.Background(), nil,
+		[]*ChatItem{{Query: "canceled"}},     // canceledItems
+		[]*ChatItem{},                         // unhandledItems
+		[]*ChatItem{approvalItem},             // newItems
+	)
+	if err != nil {
+		t.Fatalf("genResume error: %v", err)
+	}
+
+	if result.ResumeParams == nil {
+		t.Fatal("ResumeParams is nil")
+	}
+	target, ok := result.ResumeParams.Targets["interrupt-123"]
+	if !ok {
+		t.Fatal("expected target for interrupt-123")
+	}
+	ar, ok := target.(*commontool.ApprovalResult)
+	if !ok {
+		t.Fatalf("unexpected target type: %T", target)
+	}
+	if !ar.Approved {
+		t.Error("expected approved=true")
+	}
+}
+
+func TestGenResumeErrorsWithoutApproval(t *testing.T) {
+	agent := simpleReplyAgent("irrelevant")
+	srv, _, cleanup := newTestServer(t, agent)
+	defer cleanup()
+
+	genResume := srv.makeGenResume()
+
+	_, err := genResume(context.Background(), nil,
+		nil, nil,
+		[]*ChatItem{{Query: "not-an-approval"}}, // no ApprovalResult
+	)
+	if err == nil {
+		t.Fatal("expected error when no approval item is found")
+	}
+	if !strings.Contains(err.Error(), "no approval item") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Ensure our HTTP endpoints have the expected paths by checking route registration
+// does not panic.
+func TestServerRouteRegistration(t *testing.T) {
+	agent := simpleReplyAgent("test")
+	srv, _, cleanup := newTestServer(t, agent)
+	defer cleanup()
+	// Just verify the server can be constructed without error.
+	_ = srv
+}

--- a/quickstart/chatwitheino/smoketest/main.go
+++ b/quickstart/chatwitheino/smoketest/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	iter := runner.Run(ctx, messages)
 
-	lastContent, interruptID, _, err := a2ui.StreamToWriter(&jsonlPrinter{}, "smoketest", messages, iter)
+	lastContent, _, interruptID, _, err := a2ui.StreamToWriter(&jsonlPrinter{}, "smoketest", messages, iter)
 	fmt.Println()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "stream error: %v\n", err)

--- a/quickstart/chatwitheino/static/index.html
+++ b/quickstart/chatwitheino/static/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<title>Chat with Doc</title>
+<title>Chat With Eino</title>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -128,6 +128,19 @@
   }
   #send-btn:hover { background: #1d4ed8; }
   #send-btn:disabled { background: #93c5fd; cursor: not-allowed; }
+  #abort-btn {
+    display: none; padding: 9px 14px; background: #dc2626; color: #fff; border: none;
+    border-radius: 8px; cursor: pointer; font-size: 0.9rem; white-space: nowrap;
+  }
+  #abort-btn:hover { background: #b91c1c; }
+
+  /* Queued preempt indicator */
+  .preempt-chip {
+    font-size: 0.75rem; color: #d97706; padding: 4px 10px; margin-top: 4px;
+    background: #fffbeb; border: 1px solid #fcd34d; border-radius: 6px;
+    display: inline-block; animation: pulse 1.2s ease-in-out infinite;
+  }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.5} }
 
   .empty-state { text-align: center; color: #9ca3af; margin-top: 80px; font-size: 0.9rem; }
 </style>
@@ -135,7 +148,7 @@
 <body>
 
 <header>
-  <h1>Chat with Doc</h1>
+  <h1>Chat With Eino</h1>
   <button id="new-session-btn">+ New Session</button>
 </header>
 
@@ -160,6 +173,7 @@
       <div class="input-row">
         <textarea id="msg-input" placeholder="Ask about your document…" rows="1"></textarea>
         <button id="send-btn">Send</button>
+        <button id="abort-btn">Abort</button>
       </div>
     </div>
   </div>
@@ -169,6 +183,8 @@
 // ─── State ───────────────────────────────────────────────────────────────────
 let currentSessionId = null;
 let pendingInterruptId = null; // set when the agent is awaiting approval
+let isStreaming = false;       // true while an SSE stream is active
+let currentAbortController = null; // AbortController for the active fetch
 
 // A2UI renderer state
 let components = {};   // id → ComponentValue
@@ -214,14 +230,25 @@ function processA2UIMessage(msg) {
   }
 }
 
+// Auto-scroll only when user is already near the bottom (within 150px).
+function isNearBottom() {
+  const c = document.getElementById('chat-container');
+  return c.scrollHeight - c.scrollTop - c.clientHeight < 150;
+}
+function scrollToBottom(force) {
+  const c = document.getElementById('chat-container');
+  if (force || isNearBottom()) c.scrollTop = c.scrollHeight;
+}
+
 function render() {
   const container = document.getElementById('chat-container');
   if (!rootId) {
     container.innerHTML = '<div class="empty-state">Select or create a session to start chatting.</div>';
     return;
   }
+  const near = isNearBottom();
   container.innerHTML = renderComponent(rootId);
-  container.scrollTop = container.scrollHeight;
+  scrollToBottom(near);
 }
 
 function renderComponent(id) {
@@ -277,7 +304,7 @@ function renderDataBindings() {
       const html = typeof marked !== 'undefined' ? marked.parse(value) : esc(value);
       if (el.innerHTML !== html) {
         el.innerHTML = html;
-        container.scrollTop = container.scrollHeight;
+        scrollToBottom(false);
       }
     }
   });
@@ -302,7 +329,7 @@ function renderApprovalButtons(description) {
       <button class="approval-btn-reject" id="btn-reject">✗ Reject</button>
     </div>`;
   container.appendChild(div);
-  container.scrollTop = container.scrollHeight;
+  scrollToBottom(true);
 
   document.getElementById('btn-approve').addEventListener('click', () => sendApproval(true));
   document.getElementById('btn-reject').addEventListener('click', () => sendApproval(false));
@@ -316,20 +343,22 @@ function removeApprovalButtons() {
 async function sendApproval(approved) {
   if (!pendingInterruptId || !currentSessionId) return;
   removeApprovalButtons();
-  const sendBtn = document.getElementById('send-btn');
-  sendBtn.disabled = true;
 
   let reason = '';
   if (!approved) {
     reason = window.prompt('Reason for rejection (optional):') || '';
   }
 
-  let buffer = '';
+  const abortController = new AbortController();
+  currentAbortController = abortController;
+  setStreamingState(true);
+
   try {
     const res = await fetch(`/sessions/${currentSessionId}/approve`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({approved, reason}),
+      signal: abortController.signal,
     });
 
     if (!res.ok) {
@@ -339,26 +368,15 @@ async function sendApproval(approved) {
     }
 
     pendingInterruptId = null;
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    while (true) {
-      const {done, value} = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, {stream: true});
-      const lines = buffer.split('\n');
-      buffer = lines.pop();
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (trimmed.startsWith('data:')) {
-          const jsonStr = trimmed.slice(5).trimStart();
-          try { processA2UIMessage(JSON.parse(jsonStr)); } catch (_) {}
-        }
-      }
-    }
+    await consumeSSEStream(res, abortController.signal);
   } catch (err) {
+    if (abortController.signal.aborted) return;
     console.error('Approval error:', err);
   } finally {
-    sendBtn.disabled = false;
+    if (currentAbortController === abortController) {
+      currentAbortController = null;
+      setStreamingState(false);
+    }
     await loadSessions();
   }
 }
@@ -448,6 +466,67 @@ document.getElementById('file-input').addEventListener('change', async (e) => {
 });
 
 // ─── Chat ─────────────────────────────────────────────────────────────────────
+
+function setStreamingState(streaming) {
+  isStreaming = streaming;
+  document.getElementById('abort-btn').style.display = streaming ? 'inline-block' : 'none';
+}
+
+// Shows a queued user message with a preempt indicator while waiting for safe point.
+function showQueuedMessage(message) {
+  const container = document.getElementById('chat-container');
+  // Remove any existing preempt chip.
+  const existing = container.querySelector('.preempt-chip');
+  if (existing) existing.remove();
+
+  const wrapper = document.createElement('div');
+  wrapper.id = 'preempt-queue';
+  wrapper.innerHTML = `
+    <div class="card" data-role="You" style="margin-left:auto;background:#eff6ff;">
+      <div class="column"><div class="caption" style="color:#2563eb">You</div>
+      <div class="body">${esc(message)}</div></div>
+    </div>
+    <div class="preempt-chip">Preempting current turn…</div>`;
+  container.appendChild(wrapper);
+  scrollToBottom(true);
+}
+
+function removeQueuedMessage() {
+  const q = document.getElementById('preempt-queue');
+  if (q) q.remove();
+}
+
+// Reads an SSE response body and feeds A2UI messages to the renderer.
+async function consumeSSEStream(res, signal) {
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    while (true) {
+      const {done, value} = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, {stream: true});
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('data:')) {
+          const jsonStr = trimmed.slice(5).trimStart();
+          try {
+            const msg = JSON.parse(jsonStr);
+            // Once the new stream starts rendering, clear any queued indicator.
+            if (msg.beginRendering) removeQueuedMessage();
+            processA2UIMessage(msg);
+          } catch (_) {}
+        }
+      }
+    }
+  } catch (err) {
+    if (signal && signal.aborted) return; // expected abort, not an error
+    console.error('Stream error:', err);
+  }
+}
+
 async function sendMessage() {
   const input = document.getElementById('msg-input');
   const sendBtn = document.getElementById('send-btn');
@@ -464,17 +543,29 @@ async function sendMessage() {
   }
 
   input.value = '';
-  sendBtn.disabled = true;
   pendingInterruptId = null;
   removeApprovalButtons();
 
-  let buffer = '';
+  // If already streaming, this is a preempt — show queued indicator and
+  // abort the old SSE reader (the server handles Push(WithPreempt)).
+  if (isStreaming) {
+    showQueuedMessage(message);
+    if (currentAbortController) {
+      currentAbortController.abort();
+      currentAbortController = null;
+    }
+  }
+
+  const abortController = new AbortController();
+  currentAbortController = abortController;
+  setStreamingState(true);
 
   try {
     const res = await fetch(`/sessions/${currentSessionId}/chat`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({message}),
+      signal: abortController.signal,
     });
 
     if (!res.ok) {
@@ -483,36 +574,43 @@ async function sendMessage() {
       return;
     }
 
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-
-    while (true) {
-      const {done, value} = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, {stream: true});
-      const lines = buffer.split('\n');
-      buffer = lines.pop(); // last incomplete line stays in buffer
-
-      for (const line of lines) {
-        const trimmed = line.trim();
-        // SSE format: "data:{...}" or "data: {...}" — no guaranteed space
-        if (trimmed.startsWith('data:')) {
-          const jsonStr = trimmed.slice(5).trimStart();
-          try {
-            const msg = JSON.parse(jsonStr);
-            processA2UIMessage(msg);
-          } catch (_) { /* skip malformed */ }
-        }
-      }
-    }
+    await consumeSSEStream(res, abortController.signal);
   } catch (err) {
+    if (abortController.signal.aborted) return; // expected, not an error
     console.error('Chat error:', err);
   } finally {
-    sendBtn.disabled = false;
-    await loadSessions(); // refresh title in sidebar
+    if (currentAbortController === abortController) {
+      currentAbortController = null;
+      setStreamingState(false);
+    }
+    await loadSessions();
   }
 }
+
+// ─── Abort ────────────────────────────────────────────────────────────────────
+document.getElementById('abort-btn').addEventListener('click', async () => {
+  if (!currentSessionId) return;
+  // Abort the SSE reader client-side.
+  if (currentAbortController) {
+    currentAbortController.abort();
+    currentAbortController = null;
+  }
+  setStreamingState(false);
+  // Tell the server to stop the loop immediately.
+  try {
+    await fetch(`/sessions/${currentSessionId}/abort`, {method: 'POST'});
+  } catch (err) {
+    console.error('Abort error:', err);
+  }
+  // Show a visual confirmation in the chat.
+  const container = document.getElementById('chat-container');
+  const notice = document.createElement('div');
+  notice.className = 'card';
+  notice.setAttribute('data-role', 'error');
+  notice.innerHTML = '<div class="column"><div class="caption">ABORTED</div><div class="body">Agent run was stopped by user.</div></div>';
+  container.appendChild(notice);
+  scrollToBottom(true);
+});
 
 document.getElementById('send-btn').addEventListener('click', sendMessage);
 document.getElementById('msg-input').addEventListener('keydown', (e) => {

--- a/quickstart/chatwitheino/static/index.html
+++ b/quickstart/chatwitheino/static/index.html
@@ -514,6 +514,8 @@ async function consumeSSEStream(res, signal) {
           const jsonStr = trimmed.slice(5).trimStart();
           try {
             const msg = JSON.parse(jsonStr);
+            // Server signals this handler's turn was superseded by a newer preempt.
+            if (msg.event === 'preempted') { removeQueuedMessage(); return; }
             // Once the new stream starts rendering, clear any queued indicator.
             if (msg.beginRendering) removeQueuedMessage();
             processA2UIMessage(msg);
@@ -546,14 +548,18 @@ async function sendMessage() {
   pendingInterruptId = null;
   removeApprovalButtons();
 
-  // If already streaming, this is a preempt — show queued indicator and
-  // abort the old SSE reader (the server handles Push(WithPreempt)).
-  if (isStreaming) {
+  // If already streaming, this is a preempt — show queued indicator but
+  // do NOT abort the old SSE reader. Let the old turn's stream keep
+  // rendering (tool calls, model output) until the server closes it when
+  // the preempt takes effect. The new fetch will open a second concurrent
+  // SSE connection; the server starts keepalives immediately so it stays
+  // alive while the old turn drains.
+  const isPreempt = isStreaming;
+  if (isPreempt) {
     showQueuedMessage(message);
-    if (currentAbortController) {
-      currentAbortController.abort();
-      currentAbortController = null;
-    }
+    // Detach the old controller — its consumeSSEStream will finish
+    // naturally when the server closes the old stream.
+    currentAbortController = null;
   }
 
   const abortController = new AbortController();


### PR DESCRIPTION
# Replace `adk.Runner` with `TurnLoop` for Abort and Preempt Support

## Problem

The chatwitheino quickstart example used `adk.Runner` to drive agent turns. This meant every user message required a full request-response cycle with no way to:

1. **Abort** a running agent turn (e.g., the user clicks "Stop" mid-stream).
2. **Preempt** the current turn with a new user message (send a new query while the agent is still responding, gracefully replacing the old turn).

Users had to wait for the agent to finish before sending another message, which felt unresponsive for long-running tool-call chains.

## Solution

Replace `adk.Runner` with `adk.TurnLoop`, which models the agent as a persistent loop that accepts items via `Push()` and supports `Abort()` and preempt semantics via `WithPreempt`.

The server now maintains a per-session `TurnLoop` lifecycle:

1. **First message** → create loop, `Push(item)`, `Run(ctx)`.
2. **Subsequent messages** → `Push(item)` into the existing loop (auto-queued).
3. **Preempt** → `Push(item, WithPreempt(AfterToolCalls))` — the loop finishes the current tool call, then switches to the new item.
4. **Abort** → `loop.Abort()` — immediate termination, loop can be recreated.

The A2UI streamer was extended to:
- Return **intermediate messages** (tool-call messages + tool results) so the server can persist them to the session, keeping history accurate across preempts.
- Tolerate a **broken SSE writer** (browser abort during preempt) — it continues consuming events for persistence even when the HTTP response is gone.

The frontend now has an Abort button and supports sending a new message while streaming (preempt), with a visual "Preempting current turn…" indicator.

## Key Insight

When a preempt happens, two SSE connections coexist briefly: the old turn's stream draining its final events, and the new turn's stream starting keepalives. The server must **not** abort the old stream's goroutine — it needs to finish consuming events so intermediate messages (tool calls/results) are persisted to the session. The `writerBroken` flag in the A2UI streamer enables this: once the HTTP writer fails, it stops writing to the wire but keeps accumulating data for persistence.

## Summary

| Problem | Solution |
|---------|----------|
| No way to stop a running agent turn | `TurnLoop.Abort()` + Abort button in UI |
| No way to send a new message while agent is responding | `TurnLoop.Push()` with `WithPreempt(AfterToolCalls)` |
| Tool-call history lost across preempts | A2UI streamer now returns intermediate messages for session persistence |
| Browser abort during preempt kills event consumption | `writerBroken` flag lets streamer finish consuming for persistence |

---

# 替换 `adk.Runner` 为 `TurnLoop`，支持中止与抢占

## 问题

chatwitheino 快速入门示例使用 `adk.Runner` 驱动 agent 对话轮次。这意味着每条用户消息都需要完整的请求-响应周期，无法：

1. **中止**正在运行的 agent 轮次（例如用户点击"停止"）。
2. **抢占**当前轮次（在 agent 仍在回复时发送新消息，优雅地替换旧轮次）。

用户必须等待 agent 完成才能发送下一条消息，对于长链路的 tool call 场景体验很差。

## 方案

用 `adk.TurnLoop` 替换 `adk.Runner`。`TurnLoop` 将 agent 建模为持久循环，通过 `Push()` 接收输入项，支持 `Abort()` 和 `WithPreempt` 抢占语义。

服务端为每个 session 维护 `TurnLoop` 生命周期：

1. **首条消息** → 创建 loop，`Push(item)`，`Run(ctx)`。
2. **后续消息** → `Push(item)` 到已有 loop（自动排队）。
3. **抢占** → `Push(item, WithPreempt(AfterToolCalls))` — loop 等当前 tool call 完成后切换到新输入。
4. **中止** → `loop.Abort()` — 立即终止，可重建 loop。

A2UI streamer 扩展：
- 返回**中间消息**（tool-call 消息 + tool 结果），服务端可将其持久化到 session，确保抢占后历史记录准确。
- 容忍**SSE writer 断开**（浏览器在抢占时中止连接）— 即使 HTTP 响应已断，仍继续消费事件以完成持久化。

前端新增 Abort 按钮，支持在流式输出时发送新消息（抢占），并显示"正在抢占当前轮次…"提示。

## 关键洞察

抢占发生时，两条 SSE 连接短暂共存：旧轮次的流在排空最终事件，新轮次的流开始发送 keepalive。服务端**不能**中止旧流的 goroutine — 它需要继续消费事件，以便将中间消息（tool call/结果）持久化到 session。A2UI streamer 中的 `writerBroken` 标志实现了这一点：一旦 HTTP writer 失败，停止向网络写入但继续累积数据用于持久化。

## 总结

| 问题 | 方案 |
|------|------|
| 无法停止正在运行的 agent 轮次 | `TurnLoop.Abort()` + UI 中止按钮 |
| 无法在 agent 回复时发送新消息 | `TurnLoop.Push()` + `WithPreempt(AfterToolCalls)` |
| 抢占后 tool call 历史丢失 | A2UI streamer 返回中间消息用于 session 持久化 |
| 抢占时浏览器断连导致事件消费中断 | `writerBroken` 标志让 streamer 完成消费用于持久化 |
