### PR TITLE
feat(adk): add cancel graceful-exit example

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -48,15 +48,15 @@
 | [adk/multiagent/deep](https://github.com/cloudwego/eino-examples/tree/main/adk/multiagent/deep) | Deep Agents (Excel Agent) | 智能 Excel 助手，分步骤理解和处理 Excel 文件，支持 Python 代码执行 |
 | [adk/multiagent/integration-excel-agent](https://github.com/cloudwego/eino-examples/tree/main/adk/multiagent/integration-excel-agent) | Excel Agent (ADK 集成版) | ADK 集成版 Excel Agent，包含 Planner、Executor、Replanner、Reporter |
 
-### TurnLoop (推送式事件循环)
+### Agent
 | 目录 | 名称 | 说明 |
 |------|------|------|
 | [adk/agent/ralph-loop](https://github.com/cloudwego/eino-examples/tree/main/adk/agent/ralph-loop) | Ralph Loop | 自主迭代模式：外部 `for` 循环配合 `Runner.Run` 实现单轮迭代，Agent 通过文件系统感知先前工作，验证门控检查 BUG 标记后才接受完成承诺 |
 
-### Cancel (优雅退出)
+### Cancel (取消)
 | 目录 | 名称 | 说明 |
 |------|------|------|
-| [adk/cancel/graceful-exit](https://github.com/cloudwego/eino-examples/tree/main/adk/cancel/graceful-exit) | Graceful Exit | 演示 Agent Cancel + Resume：捕获 Ctrl-C 信号后以 `CancelAfterChatModel` 模式优雅取消，等待安全点保存 Checkpoint，然后从 Checkpoint 恢复继续执行 |
+| [adk/cancel/graceful-exit](https://github.com/cloudwego/eino-examples/tree/main/adk/cancel/graceful-exit) | Graceful Exit | 演示 Agent Cancel + Resume：捕获终端信号后以 `CancelAfterChatModel` + `WithRecursive` 模式取消嵌套 Agent，等待安全点保存 Checkpoint，然后恢复继续执行 |
 
 ### Middlewares (中间件)
 | 目录 | 名称 | 说明 |

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -51,7 +51,12 @@
 ### TurnLoop (推送式事件循环)
 | 目录 | 名称 | 说明 |
 |------|------|------|
-| [adk/turn-loop/ralph-loop](https://github.com/cloudwego/eino-examples/tree/main/adk/turn-loop/ralph-loop) | Ralph Loop | 基于 TurnLoop 的自主迭代模式：相同 Prompt 反复推送，Agent 通过文件系统感知先前工作，验证门控检查 BUG 标记后才接受完成承诺 |
+| [adk/agent/ralph-loop](https://github.com/cloudwego/eino-examples/tree/main/adk/agent/ralph-loop) | Ralph Loop | 自主迭代模式：外部 `for` 循环配合 `Runner.Run` 实现单轮迭代，Agent 通过文件系统感知先前工作，验证门控检查 BUG 标记后才接受完成承诺 |
+
+### Cancel (优雅退出)
+| 目录 | 名称 | 说明 |
+|------|------|------|
+| [adk/cancel/graceful-exit](https://github.com/cloudwego/eino-examples/tree/main/adk/cancel/graceful-exit) | Graceful Exit | 演示 Agent Cancel + Resume：捕获 Ctrl-C 信号后以 `CancelAfterChatModel` 模式优雅取消，等待安全点保存 Checkpoint，然后从 Checkpoint 恢复继续执行 |
 
 ### Middlewares (中间件)
 | 目录 | 名称 | 说明 |

--- a/adk/cancel/graceful-exit/main.go
+++ b/adk/cancel/graceful-exit/main.go
@@ -24,47 +24,63 @@
 // cancel automatically persists a checkpoint. A new Runner can later resume from
 // that checkpoint, continuing exactly where the agent was interrupted.
 //
-// The agent is configured with tools so it makes multiple ChatModel → ToolCall
-// rounds. This is essential: CancelAfterChatModel fires BETWEEN rounds (after a
-// ChatModel call finishes), meaning the resume has remaining work to continue.
-// Without tools, a single-round agent finishes entirely in one ChatModel call,
-// leaving nothing to resume.
+// The agent is configured with tools AND a nested AgentTool so it makes
+// multiple ChatModel → ToolCall rounds across agent layers. This is essential:
+// CancelAfterChatModel fires BETWEEN rounds (after a ChatModel call finishes),
+// and WithRecursive propagates the cancel to the nested agent inside the
+// AgentTool, so whichever layer's ChatModel finishes first triggers the cancel.
+// This speeds up the graceful exit because the inner agent can reach its own
+// safe-point independently of the outer agent.
 //
 // This example runs in two phases:
 //
-//  1. Run + Cancel — An agent starts a multi-step research task (using tools).
-//     When the user presses Ctrl-C (SIGINT/SIGTERM), the cancel function fires
-//     with CancelAfterChatModel mode and a 30-second timeout. The cancel waits
-//     for the current ChatModel call to finish (the graceful safe-point), then
-//     saves the checkpoint. If it doesn't finish within 30 seconds, the cancel
-//     escalates to CancelImmediate.
+//  1. Run + Cancel — A root agent starts a multi-step research task, delegating
+//     analysis to a nested sub-agent via AgentTool. When the user presses
+//     Ctrl-C (SIGINT/SIGTERM), the cancel function fires with CancelAfterChatModel
+//     mode, WithRecursive, and a 30-second timeout. WithRecursive propagates the
+//     cancel into the nested agent — whichever layer's ChatModel finishes first
+//     triggers the safe-point, speeding up the graceful exit. The checkpoint is
+//     saved automatically. If no safe-point is reached within 30 seconds, the
+//     cancel escalates to CancelImmediate.
 //
 //  2. Resume — A new Runner resumes from the saved checkpoint. The agent
-//     continues its remaining tool calls and final response.
+//     continues from whatever layer was interrupted and completes the task.
 //
 // # Key ADK APIs Demonstrated
 //
 //   - adk.WithCancel() — creates a cancel option + cancel function pair
 //   - adk.WithCheckPointID(id) — associates a checkpoint ID with the run
 //   - adk.WithAgentCancelMode(adk.CancelAfterChatModel) — waits for ChatModel safe-point
+//   - adk.WithRecursive() — propagates cancel to nested AgentTools for faster safe-point
 //   - adk.WithAgentCancelTimeout(d) — escalates to CancelImmediate after timeout
 //   - adk.CancelError — the error surfaced via AgentEvent.Err on cancellation
+//   - adk.NewAgentTool — wraps an Agent as a tool for nested agent topology
 //   - Runner.Resume(ctx, checkpointID) — resumes from saved checkpoint
 //
 // # How to Run
 //
-// Set the model environment variables (see adk/common/model for details):
+// Set the model environment variables (see adk/common/model for details).
+//
+// Option A — OpenAI:
 //
 //	export OPENAI_API_KEY=sk-...
 //	export OPENAI_MODEL=gpt-4o
 //	export OPENAI_BASE_URL=https://api.openai.com/v1
 //
+// Option B — Ark (Volcengine):
+//
+//	export MODEL_TYPE=ark
+//	export ARK_API_KEY=...
+//	export ARK_MODEL=...
+//	export ARK_BASE_URL=...
+//
 // Then run:
 //
 //	go run ./adk/cancel/graceful-exit/
 //
-// Press Ctrl-C while the agent is working to trigger the cancel. The program
-// will print the cancel info, then automatically resume and complete the task.
+// Press Ctrl-C while the agent is working to trigger the cancel. WithRecursive
+// ensures the cancel reaches whichever agent layer is active. The program will
+// print the cancel info, then automatically resume and complete the task.
 package main
 
 import (
@@ -109,9 +125,11 @@ func sysMsgf(color, format string, args ...any) {
 
 const checkpointID = "graceful-exit-demo"
 
-// --- Mock tools that simulate a multi-step research workflow ---
-// The agent will call these tools across multiple rounds, giving us a window
-// between ChatModel calls where CancelAfterChatModel can fire.
+// --- Mock tools for the nested agent topology ---
+// The root agent uses search_web, then delegates to the analyst AgentTool.
+// The analyst sub-agent uses analyze_data and summarize_findings.
+// This creates multiple ChatModel calls across two agent layers, giving
+// WithRecursive a window to propagate CancelAfterChatModel inward.
 
 type searchInput struct {
 	Query string `json:"query" jsonschema:"description=The search query"`
@@ -172,23 +190,53 @@ func main() {
 		log.Fatalf("create summarize tool: %v", err)
 	}
 
-	// Create an agent with tools. The instruction encourages using ALL tools
-	// in sequence, creating multiple ChatModel rounds (ChatModel → ToolCalls → ChatModel → ...).
-	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
-		Name:        "researcher",
-		Description: "A research assistant that searches, analyzes, and summarizes",
-		Instruction: "You are a research assistant. When given a research topic, " +
-			"you MUST follow this workflow step by step:\n" +
-			"1. Use search_web to find information.\n" +
-			"2. Use analyze_data to analyze the search results.\n" +
-			"3. Use summarize_findings to create a final summary.\n" +
-			"4. Present the summary to the user with your commentary.\n" +
-			"Always use ALL three tools in order before giving your final answer.",
+	// --- Sub-agent: "analyst" ---
+	// This agent owns the analyze + summarize tools. It is wrapped as an AgentTool
+	// so the outer agent delegates analysis work to it. This creates a nested agent
+	// topology where WithRecursive can propagate the cancel inward.
+	analyst, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "analyst",
+		Description: "Analyzes search results and produces a summary report",
+		Instruction: "You are a data analyst. When given search results:\n" +
+			"1. Use analyze_data to analyze the content.\n" +
+			"2. Use summarize_findings to produce a final summary.\n" +
+			"Always use BOTH tools before giving your answer.",
 		Model: chatModel,
 		ToolsConfig: adk.ToolsConfig{
 			ToolsNodeConfig: compose.ToolsNodeConfig{
-				Tools: []einotool.BaseTool{searchTool, analyzeTool, summarizeTool},
+				Tools: []einotool.BaseTool{analyzeTool, summarizeTool},
 			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("create analyst agent: %v", err)
+	}
+
+	// Wrap the analyst as an AgentTool. The outer agent can call it like any tool.
+	analystTool := adk.NewAgentTool(ctx, analyst)
+
+	// --- Root agent: "researcher" ---
+	// Uses search_web directly and delegates analysis to the analyst AgentTool.
+	// This creates the topology:
+	//   researcher (ChatModel → search_web / analyst_tool)
+	//     └── analyst (ChatModel → analyze_data / summarize_findings)
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "researcher",
+		Description: "A research assistant that searches and delegates analysis",
+		Instruction: "You are a research assistant. When given a research topic, " +
+			"you MUST follow this workflow:\n" +
+			"1. Use search_web to find information.\n" +
+			"2. Use the analyst tool to analyze and summarize the results.\n" +
+			"3. Present the final summary to the user with your commentary.\n" +
+			"Always use search_web first, then delegate to the analyst.",
+		Model: chatModel,
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []einotool.BaseTool{searchTool, analystTool},
+			},
+			// EmitInternalEvents surfaces the nested analyst agent's events
+			// in the top-level AsyncIterator, so we can see it working in real-time.
+			EmitInternalEvents: true,
 		},
 	})
 	if err != nil {
@@ -230,13 +278,14 @@ func main() {
 		sysMsgf(colorYellow, "⚡ Received signal: %v — requesting cancel...", sig)
 
 		// CancelAfterChatModel: wait for the current ChatModel call to finish
-		// before canceling. Since the agent uses tools, there are multiple
-		// ChatModel calls. The cancel fires at the NEXT safe-point (end of a
-		// ChatModel call), preserving all completed tool results in the checkpoint.
-		// WithAgentCancelTimeout: if the safe-point is not reached within 30s,
+		// before canceling. WithRecursive propagates the cancel to the nested
+		// analyst AgentTool — whichever layer's ChatModel finishes first triggers
+		// the cancel, speeding up the graceful exit.
+		// WithAgentCancelTimeout: if no safe-point is reached within 30s,
 		// escalate to CancelImmediate as a last resort.
 		handle, contributed := cancelFn(
 			adk.WithAgentCancelMode(adk.CancelAfterChatModel),
+			adk.WithRecursive(),
 			adk.WithAgentCancelTimeout(30*time.Second),
 		)
 		sysMsgf(colorYellow, "⚡ Cancel contributed: %v", contributed)
@@ -279,7 +328,7 @@ func main() {
 	})
 
 	// Resume picks up from the checkpoint saved during cancellation.
-	// The agent continues from wherever it was interrupted in the tool workflow.
+	// The agent continues from whatever layer (root or nested) was interrupted.
 	resumeIter, err := resumeRunner.Resume(ctx, checkpointID)
 	if err != nil {
 		log.Fatalf("resume failed: %v", err)
@@ -293,6 +342,7 @@ func main() {
 
 // drainEvents consumes all events from the iterator, printing output and
 // detecting CancelError. Returns true if a CancelError was encountered.
+// Events are prefixed with the agent name to distinguish top-level vs nested output.
 func drainEvents(iter *adk.AsyncIterator[*adk.AgentEvent]) bool {
 	for {
 		event, ok := iter.Next()
@@ -314,9 +364,13 @@ func drainEvents(iter *adk.AsyncIterator[*adk.AgentEvent]) bool {
 			return false
 		}
 
-		// Print streamed/non-streamed message content in cyan.
+		// Determine display prefix based on which agent emitted the event.
+		prefix := fmt.Sprintf("[%s] ", event.AgentName)
+
+		// Print streamed/non-streamed message content.
 		if event.Output != nil && event.Output.MessageOutput != nil {
 			if s := event.Output.MessageOutput.MessageStream; s != nil {
+				first := true
 				for {
 					chunk, recvErr := s.Recv()
 					if recvErr != nil {
@@ -326,19 +380,26 @@ func drainEvents(iter *adk.AsyncIterator[*adk.AgentEvent]) bool {
 						// StreamCanceledError is expected when CancelImmediate fires.
 						break
 					}
-					fmt.Print(colorCyan + chunk.Content + colorReset)
+					if first {
+						fmt.Print(colorDim + prefix + colorReset + colorCyan)
+						first = false
+					}
+					fmt.Print(chunk.Content)
+				}
+				if !first {
+					fmt.Print(colorReset + "\n")
 				}
 			} else if m := event.Output.MessageOutput.Message; m != nil {
 				if m.Content != "" {
-					fmt.Print(colorCyan + m.Content + colorReset)
+					fmt.Printf("%s%s%s%s%s%s\n", colorDim, prefix, colorReset, colorCyan, m.Content, colorReset)
 				}
 				// Show tool call invocations for visibility.
 				for _, tc := range m.ToolCalls {
-					sysMsgf(colorDim, "  → tool call: %s(%s)", tc.Function.Name, tc.Function.Arguments)
+					sysMsgf(colorDim, "%s  → tool call: %s(%s)", prefix, tc.Function.Name, tc.Function.Arguments)
 				}
 				// Show tool results.
 				if m.Role == schema.Tool {
-					sysMsgf(colorDim, "  ← tool result: %.100s...", m.Content)
+					sysMsgf(colorDim, "%s  ← tool result: %.100s...", prefix, m.Content)
 				}
 			}
 		}

--- a/adk/cancel/graceful-exit/main.go
+++ b/adk/cancel/graceful-exit/main.go
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package main demonstrates graceful agent cancellation on OS interrupt (Ctrl-C)
+// and subsequent resumption from a saved checkpoint.
+//
+// # What This Example Shows
+//
+// The ADK Cancel mechanism (adk.WithCancel) lets you shut down a running agent
+// cleanly, without losing progress. When a CheckPointStore is configured, the
+// cancel automatically persists a checkpoint. A new Runner can later resume from
+// that checkpoint, continuing exactly where the agent was interrupted.
+//
+// The agent is configured with tools so it makes multiple ChatModel → ToolCall
+// rounds. This is essential: CancelAfterChatModel fires BETWEEN rounds (after a
+// ChatModel call finishes), meaning the resume has remaining work to continue.
+// Without tools, a single-round agent finishes entirely in one ChatModel call,
+// leaving nothing to resume.
+//
+// This example runs in two phases:
+//
+//  1. Run + Cancel — An agent starts a multi-step research task (using tools).
+//     When the user presses Ctrl-C (SIGINT/SIGTERM), the cancel function fires
+//     with CancelAfterChatModel mode and a 30-second timeout. The cancel waits
+//     for the current ChatModel call to finish (the graceful safe-point), then
+//     saves the checkpoint. If it doesn't finish within 30 seconds, the cancel
+//     escalates to CancelImmediate.
+//
+//  2. Resume — A new Runner resumes from the saved checkpoint. The agent
+//     continues its remaining tool calls and final response.
+//
+// # Key ADK APIs Demonstrated
+//
+//   - adk.WithCancel() — creates a cancel option + cancel function pair
+//   - adk.WithCheckPointID(id) — associates a checkpoint ID with the run
+//   - adk.WithAgentCancelMode(adk.CancelAfterChatModel) — waits for ChatModel safe-point
+//   - adk.WithAgentCancelTimeout(d) — escalates to CancelImmediate after timeout
+//   - adk.CancelError — the error surfaced via AgentEvent.Err on cancellation
+//   - Runner.Resume(ctx, checkpointID) — resumes from saved checkpoint
+//
+// # How to Run
+//
+// Set the model environment variables (see adk/common/model for details):
+//
+//	export OPENAI_API_KEY=sk-...
+//	export OPENAI_MODEL=gpt-4o
+//	export OPENAI_BASE_URL=https://api.openai.com/v1
+//
+// Then run:
+//
+//	go run ./adk/cancel/graceful-exit/
+//
+// Press Ctrl-C while the agent is working to trigger the cancel. The program
+// will print the cancel info, then automatically resume and complete the task.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/cloudwego/eino/adk"
+	einotool "github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/components/tool/utils"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/schema"
+
+	commonmodel "github.com/cloudwego/eino-examples/adk/common/model"
+	"github.com/cloudwego/eino-examples/adk/common/store"
+)
+
+// ANSI escape codes for colored terminal output.
+// System messages (cancel info, phase headers) use these to stand out from model output.
+const (
+	colorReset  = "\033[0m"
+	colorYellow = "\033[33m" // cancel/signal messages
+	colorGreen  = "\033[32m" // phase headers / success
+	colorRed    = "\033[31m" // errors / escalation
+	colorCyan   = "\033[36m" // model output
+	colorDim    = "\033[2m"  // dimmed separator lines
+)
+
+func sysMsg(color, msg string) {
+	fmt.Printf("\n%s%s%s\n", color, msg, colorReset)
+}
+
+func sysMsgf(color, format string, args ...any) {
+	fmt.Printf("\n%s"+format+"%s\n", append([]any{color}, append(args, colorReset)...)...)
+}
+
+const checkpointID = "graceful-exit-demo"
+
+// --- Mock tools that simulate a multi-step research workflow ---
+// The agent will call these tools across multiple rounds, giving us a window
+// between ChatModel calls where CancelAfterChatModel can fire.
+
+type searchInput struct {
+	Query string `json:"query" jsonschema:"description=The search query"`
+}
+
+type analyzeInput struct {
+	Content string `json:"content" jsonschema:"description=The content to analyze"`
+	Aspect  string `json:"aspect" jsonschema:"description=The aspect to focus on"`
+}
+
+type summarizeInput struct {
+	Findings []string `json:"findings" jsonschema:"description=List of findings to summarize"`
+}
+
+func searchWeb(_ context.Context, input *searchInput) (string, error) {
+	// Simulate a slow network call — gives the user time to press Ctrl-C.
+	time.Sleep(500 * time.Millisecond)
+	return fmt.Sprintf("[Search results for %q]: "+
+		"1. Ancient radio signals detected from Proxima Centauri system. "+
+		"2. New study suggests periodic patterns in deep-space signals. "+
+		"3. SETI confirms non-natural origin hypothesis for Signal X-47.", input.Query), nil
+}
+
+func analyzeData(_ context.Context, input *analyzeInput) (string, error) {
+	time.Sleep(500 * time.Millisecond)
+	return fmt.Sprintf("[Analysis of %q focusing on %q]: "+
+		"The pattern exhibits a 73-second periodicity with mathematical structure "+
+		"consistent with an artificial origin. Confidence level: 94%%.", input.Content, input.Aspect), nil
+}
+
+func summarizeFindings(_ context.Context, input *summarizeInput) (string, error) {
+	time.Sleep(300 * time.Millisecond)
+	return fmt.Sprintf("[Summary of %d findings]: "+
+		"Multiple independent analyses confirm the signal's artificial nature. "+
+		"Recommended action: escalate to priority observation queue.", len(input.Findings)), nil
+}
+
+func main() {
+	ctx := context.Background()
+
+	chatModel := commonmodel.NewChatModel()
+	cpStore := store.NewInMemoryStore()
+
+	// Create tools using utils.InferTool — these give the agent multi-round behavior.
+	searchTool, err := utils.InferTool("search_web",
+		"Search the web for information on a given query. Returns relevant articles.", searchWeb)
+	if err != nil {
+		log.Fatalf("create search tool: %v", err)
+	}
+	analyzeTool, err := utils.InferTool("analyze_data",
+		"Analyze a piece of content focusing on a specific aspect.", analyzeData)
+	if err != nil {
+		log.Fatalf("create analyze tool: %v", err)
+	}
+	summarizeTool, err := utils.InferTool("summarize_findings",
+		"Summarize a list of findings into a concise report.", summarizeFindings)
+	if err != nil {
+		log.Fatalf("create summarize tool: %v", err)
+	}
+
+	// Create an agent with tools. The instruction encourages using ALL tools
+	// in sequence, creating multiple ChatModel rounds (ChatModel → ToolCalls → ChatModel → ...).
+	agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+		Name:        "researcher",
+		Description: "A research assistant that searches, analyzes, and summarizes",
+		Instruction: "You are a research assistant. When given a research topic, " +
+			"you MUST follow this workflow step by step:\n" +
+			"1. Use search_web to find information.\n" +
+			"2. Use analyze_data to analyze the search results.\n" +
+			"3. Use summarize_findings to create a final summary.\n" +
+			"4. Present the summary to the user with your commentary.\n" +
+			"Always use ALL three tools in order before giving your final answer.",
+		Model: chatModel,
+		ToolsConfig: adk.ToolsConfig{
+			ToolsNodeConfig: compose.ToolsNodeConfig{
+				Tools: []einotool.BaseTool{searchTool, analyzeTool, summarizeTool},
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("create agent: %v", err)
+	}
+
+	input := []adk.Message{
+		schema.UserMessage("Research the topic: mysterious deep-space radio signals and their potential artificial origins."),
+	}
+
+	// =====================================================================
+	// Phase 1: Run the agent with cancel support
+	// =====================================================================
+	sysMsg(colorGreen, "╔══════════════════════════════════════════════════════════════╗")
+	sysMsg(colorGreen, "║  Phase 1: Running agent (press Ctrl-C to cancel)            ║")
+	sysMsg(colorGreen, "╚══════════════════════════════════════════════════════════════╝")
+	fmt.Println()
+
+	runner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:           agent,
+		EnableStreaming: true,
+		CheckPointStore: cpStore,
+	})
+
+	// WithCancel returns:
+	//   cancelOpt  — pass to Runner.Run to enable cancellation for this execution
+	//   cancelFn   — call this function to request cancellation
+	cancelOpt, cancelFn := adk.WithCancel()
+
+	// WithCheckPointID associates a checkpoint ID so the cancel can persist state.
+	iter := runner.Run(ctx, input, cancelOpt, adk.WithCheckPointID(checkpointID))
+
+	// Listen for OS interrupt signals in a separate goroutine.
+	// When Ctrl-C is pressed, we request a graceful cancel.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		sysMsgf(colorYellow, "⚡ Received signal: %v — requesting cancel...", sig)
+
+		// CancelAfterChatModel: wait for the current ChatModel call to finish
+		// before canceling. Since the agent uses tools, there are multiple
+		// ChatModel calls. The cancel fires at the NEXT safe-point (end of a
+		// ChatModel call), preserving all completed tool results in the checkpoint.
+		// WithAgentCancelTimeout: if the safe-point is not reached within 30s,
+		// escalate to CancelImmediate as a last resort.
+		handle, contributed := cancelFn(
+			adk.WithAgentCancelMode(adk.CancelAfterChatModel),
+			adk.WithAgentCancelTimeout(30*time.Second),
+		)
+		sysMsgf(colorYellow, "⚡ Cancel contributed: %v", contributed)
+
+		// Wait blocks until the cancel reaches a terminal state.
+		if waitErr := handle.Wait(); waitErr != nil {
+			sysMsgf(colorRed, "⚡ Cancel wait result: %v", waitErr)
+		} else {
+			sysMsg(colorGreen, "⚡ Cancel completed successfully — checkpoint saved")
+		}
+	}()
+
+	// Consume the event stream.
+	canceled := drainEvents(iter)
+
+	// Stop listening for signals — Phase 2 should not be interrupted.
+	signal.Stop(sigCh)
+
+	if !canceled {
+		sysMsg(colorGreen, "Agent completed without cancellation.")
+		return
+	}
+
+	// =====================================================================
+	// Phase 2: Resume from the saved checkpoint
+	// =====================================================================
+	fmt.Println()
+	sysMsg(colorGreen, "╔══════════════════════════════════════════════════════════════╗")
+	sysMsg(colorGreen, "║  Phase 2: Resuming from checkpoint                          ║")
+	sysMsg(colorGreen, "╚══════════════════════════════════════════════════════════════╝")
+	fmt.Println()
+
+	// Create a new Runner with the same agent and the same CheckPointStore.
+	// In production, the store would be a persistent backend (Redis, DB, etc.)
+	// and the resume could happen in a different process or after a restart.
+	resumeRunner := adk.NewRunner(ctx, adk.RunnerConfig{
+		Agent:           agent,
+		EnableStreaming: true,
+		CheckPointStore: cpStore,
+	})
+
+	// Resume picks up from the checkpoint saved during cancellation.
+	// The agent continues from wherever it was interrupted in the tool workflow.
+	resumeIter, err := resumeRunner.Resume(ctx, checkpointID)
+	if err != nil {
+		log.Fatalf("resume failed: %v", err)
+	}
+
+	drainEvents(resumeIter)
+
+	fmt.Println()
+	sysMsg(colorGreen, "✓ Done — agent resumed and completed successfully.")
+}
+
+// drainEvents consumes all events from the iterator, printing output and
+// detecting CancelError. Returns true if a CancelError was encountered.
+func drainEvents(iter *adk.AsyncIterator[*adk.AgentEvent]) bool {
+	for {
+		event, ok := iter.Next()
+		if !ok {
+			return false
+		}
+
+		if event.Err != nil {
+			var cancelErr *adk.CancelError
+			if errors.As(event.Err, &cancelErr) {
+				sysMsg(colorDim, "────────────────────────────────────────────────────────────")
+				sysMsg(colorYellow, "⚡ CancelError received:")
+				sysMsgf(colorYellow, "    Mode:      %v", cancelErr.Info.Mode)
+				sysMsgf(colorYellow, "    Escalated: %v", cancelErr.Info.Escalated)
+				sysMsg(colorDim, "────────────────────────────────────────────────────────────")
+				return true
+			}
+			log.Printf("unexpected error: %v", event.Err)
+			return false
+		}
+
+		// Print streamed/non-streamed message content in cyan.
+		if event.Output != nil && event.Output.MessageOutput != nil {
+			if s := event.Output.MessageOutput.MessageStream; s != nil {
+				for {
+					chunk, recvErr := s.Recv()
+					if recvErr != nil {
+						if recvErr == io.EOF {
+							break
+						}
+						// StreamCanceledError is expected when CancelImmediate fires.
+						break
+					}
+					fmt.Print(colorCyan + chunk.Content + colorReset)
+				}
+			} else if m := event.Output.MessageOutput.Message; m != nil {
+				if m.Content != "" {
+					fmt.Print(colorCyan + m.Content + colorReset)
+				}
+				// Show tool call invocations for visibility.
+				for _, tc := range m.ToolCalls {
+					sysMsgf(colorDim, "  → tool call: %s(%s)", tc.Function.Name, tc.Function.Arguments)
+				}
+				// Show tool results.
+				if m.Role == schema.Tool {
+					sysMsgf(colorDim, "  ← tool result: %.100s...", m.Content)
+				}
+			}
+		}
+	}
+}

--- a/adk/intro/http-sse-service/go.mod
+++ b/adk/intro/http-sse-service/go.mod
@@ -5,7 +5,7 @@ go 1.24.9
 replace github.com/cloudwego/eino-examples => ../../..
 
 require (
-	github.com/cloudwego/eino v0.9.0-alpha.18
+	github.com/cloudwego/eino v0.9.0-alpha.22
 	github.com/cloudwego/eino-examples v0.0.0-00010101000000-000000000000
 	github.com/cloudwego/hertz v0.10.3
 	github.com/hertz-contrib/sse v0.1.0
@@ -49,7 +49,7 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/volcengine/volc-sdk-golang v1.0.199 // indirect
-	github.com/volcengine/volcengine-go-sdk v1.2.9 // indirect
+	github.com/volcengine/volcengine-go-sdk v1.2.27 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yargevad/filepathx v1.0.0 // indirect
 	golang.org/x/arch v0.19.0 // indirect

--- a/adk/intro/http-sse-service/go.mod
+++ b/adk/intro/http-sse-service/go.mod
@@ -5,7 +5,7 @@ go 1.24.9
 replace github.com/cloudwego/eino-examples => ../../..
 
 require (
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-alpha.24
 	github.com/cloudwego/eino-examples v0.0.0-00010101000000-000000000000
 	github.com/cloudwego/hertz v0.10.3
 	github.com/hertz-contrib/sse v0.1.0

--- a/adk/intro/http-sse-service/go.sum
+++ b/adk/intro/http-sse-service/go.sum
@@ -107,6 +107,7 @@ github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gE
 github.com/cloudwego/eino v0.9.0-alpha.18 h1:xBd6wReRd8a4kcICvtVAaDZywMQ5Yw+ip+xCitm7y30=
 github.com/cloudwego/eino v0.9.0-alpha.18/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-alpha.24/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/components/model/ark v0.1.65 h1:52ukXVU9ntToTa36SwI8be81qskGkpUEZraIFOf0wqk=
 github.com/cloudwego/eino-ext/components/model/ark v0.1.65/go.mod h1:aabMR15RTXBSi9Eu13CWavzE+no5BQO4FJUEEdqImbg=
 github.com/cloudwego/eino-ext/components/model/openai v0.1.12 h1:vcwNXeT7bpaXMNwUhtcHZwMYY8II2jAihuooyivmEZ0=

--- a/adk/intro/http-sse-service/go.sum
+++ b/adk/intro/http-sse-service/go.sum
@@ -106,6 +106,7 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.9.0-alpha.18 h1:xBd6wReRd8a4kcICvtVAaDZywMQ5Yw+ip+xCitm7y30=
 github.com/cloudwego/eino v0.9.0-alpha.18/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/components/model/ark v0.1.65 h1:52ukXVU9ntToTa36SwI8be81qskGkpUEZraIFOf0wqk=
 github.com/cloudwego/eino-ext/components/model/ark v0.1.65/go.mod h1:aabMR15RTXBSi9Eu13CWavzE+no5BQO4FJUEEdqImbg=
 github.com/cloudwego/eino-ext/components/model/openai v0.1.12 h1:vcwNXeT7bpaXMNwUhtcHZwMYY8II2jAihuooyivmEZ0=
@@ -510,6 +511,7 @@ github.com/volcengine/volc-sdk-golang v1.0.199 h1:zv9QOqTl/IsLwtfC37GlJtcz6vMAHi
 github.com/volcengine/volc-sdk-golang v1.0.199/go.mod h1:stZX+EPgv1vF4nZwOlEe8iGcriUPRBKX8zA19gXycOQ=
 github.com/volcengine/volcengine-go-sdk v1.2.9 h1:du2gnImtyWXKkQFnJW/GXCs+UBibGGOXIbP1Ams2pB8=
 github.com/volcengine/volcengine-go-sdk v1.2.9/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.2.27/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=

--- a/flow/agent/deer-go/go.mod
+++ b/flow/agent/deer-go/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.7
 
 require (
 	github.com/RanFeng/ilog v1.1.0
-	github.com/cloudwego/eino v0.9.0-alpha.18
+	github.com/cloudwego/eino v0.9.0-alpha.24
 	github.com/cloudwego/eino-ext/callbacks/apmplus v0.0.1
 	github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0
 	github.com/cloudwego/eino-ext/components/model/openai v0.1.12

--- a/flow/agent/deer-go/go.sum
+++ b/flow/agent/deer-go/go.sum
@@ -38,8 +38,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.18 h1:xBd6wReRd8a4kcICvtVAaDZywMQ5Yw+ip+xCitm7y30=
-github.com/cloudwego/eino v0.9.0-alpha.18/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-alpha.24 h1:iUTgAHYARvR3N10PvxJxo9hkhshdmgP0kw4Itj2Lsbw=
+github.com/cloudwego/eino v0.9.0-alpha.24/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/callbacks/apmplus v0.0.1 h1:aP9vfE61IBQXTjTiHf4gHUJ0QlgmVYlvZgmvxgVFkE8=
 github.com/cloudwego/eino-ext/callbacks/apmplus v0.0.1/go.mod h1:9WpHGYt5Ix2TeiTkY5oRzgt+d11KovNp73tufD5C9Ac=
 github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0 h1:KZ4HuOG/7xbx4bifxUL4zADTkeGwZ4vhqfUsIlFn12c=

--- a/flow/agent/manus/go.mod
+++ b/flow/agent/manus/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.1
 
 require (
-	github.com/cloudwego/eino v0.9.0-alpha.18
+	github.com/cloudwego/eino v0.9.0-alpha.24
 	github.com/cloudwego/eino-ext/callbacks/cozeloop v0.1.4
 	github.com/cloudwego/eino-ext/callbacks/langfuse v0.0.0-20250415073426-726b929afbc2
 	github.com/cloudwego/eino-ext/components/model/openai v0.0.0-20250422100419-a2ef28c59573

--- a/flow/agent/manus/go.sum
+++ b/flow/agent/manus/go.sum
@@ -34,8 +34,8 @@ github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipw
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.18 h1:xBd6wReRd8a4kcICvtVAaDZywMQ5Yw+ip+xCitm7y30=
-github.com/cloudwego/eino v0.9.0-alpha.18/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-alpha.24 h1:iUTgAHYARvR3N10PvxJxo9hkhshdmgP0kw4Itj2Lsbw=
+github.com/cloudwego/eino v0.9.0-alpha.24/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/callbacks/cozeloop v0.1.4 h1:Cwm80+fMEAoY7uI9XUukDEV5J3Adb9HiXKmcXpXcDiM=
 github.com/cloudwego/eino-ext/callbacks/cozeloop v0.1.4/go.mod h1:xxjNsJeZwdIooEYTt6tjw/YJzkA6xPcxn1u/HvA5xc0=
 github.com/cloudwego/eino-ext/callbacks/langfuse v0.0.0-20250415073426-726b929afbc2 h1:M/u7nNq1dXEKlwjy2CMUefO/lFk5zBPbm/r2G70TXGc=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/bytedance/sonic v1.15.0
 	github.com/chromedp/chromedp v0.9.5
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-alpha.24
 	github.com/cloudwego/eino-ext/adk/backend/local v0.2.1
 	github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0
 	github.com/cloudwego/eino-ext/components/document/parser/html v0.0.0-20251117090452-bd6375a0b3cf

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.9.0-alpha.22 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
 github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-alpha.24 h1:iUTgAHYARvR3N10PvxJxo9hkhshdmgP0kw4Itj2Lsbw=
+github.com/cloudwego/eino v0.9.0-alpha.24/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/adk/backend/local v0.2.1 h1:sZ4f21SFzygzVXI6ppkkZom6JOibAjvS+YT2GZMqIy0=
 github.com/cloudwego/eino-ext/adk/backend/local v0.2.1/go.mod h1:os5Tq5FuSoz/MLqAdZER3ip49Oef9prc0kVsKsPYO48=
 github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0 h1:KZ4HuOG/7xbx4bifxUL4zADTkeGwZ4vhqfUsIlFn12c=

--- a/quickstart/chatwitheino/go.mod
+++ b/quickstart/chatwitheino/go.mod
@@ -5,7 +5,7 @@ go 1.24.9
 replace github.com/cloudwego/eino-examples => ../..
 
 require (
-	github.com/cloudwego/eino v0.9.0-alpha.18
+	github.com/cloudwego/eino v0.9.0-alpha.22
 	github.com/cloudwego/eino-examples v0.0.0-00010101000000-000000000000
 	github.com/cloudwego/eino-ext/adk/backend/local v0.2.2
 	github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0
@@ -59,7 +59,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/volcengine/volc-sdk-golang v1.0.199 // indirect
-	github.com/volcengine/volcengine-go-sdk v1.2.9 // indirect
+	github.com/volcengine/volcengine-go-sdk v1.2.27 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yargevad/filepathx v1.0.0 // indirect
 	golang.org/x/arch v0.19.0 // indirect

--- a/quickstart/chatwitheino/go.mod
+++ b/quickstart/chatwitheino/go.mod
@@ -5,7 +5,7 @@ go 1.24.9
 replace github.com/cloudwego/eino-examples => ../..
 
 require (
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-alpha.24
 	github.com/cloudwego/eino-examples v0.0.0-00010101000000-000000000000
 	github.com/cloudwego/eino-ext/adk/backend/local v0.2.2
 	github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0

--- a/quickstart/chatwitheino/go.sum
+++ b/quickstart/chatwitheino/go.sum
@@ -112,6 +112,7 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.9.0-alpha.18 h1:xBd6wReRd8a4kcICvtVAaDZywMQ5Yw+ip+xCitm7y30=
 github.com/cloudwego/eino v0.9.0-alpha.18/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/adk/backend/local v0.2.2 h1:IWuzl4uZf4IkMN98ieRe9Ajl9E8L90twJh7gFBPXOrQ=
 github.com/cloudwego/eino-ext/adk/backend/local v0.2.2/go.mod h1:os5Tq5FuSoz/MLqAdZER3ip49Oef9prc0kVsKsPYO48=
 github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0 h1:KZ4HuOG/7xbx4bifxUL4zADTkeGwZ4vhqfUsIlFn12c=
@@ -542,6 +543,7 @@ github.com/volcengine/volc-sdk-golang v1.0.199 h1:zv9QOqTl/IsLwtfC37GlJtcz6vMAHi
 github.com/volcengine/volc-sdk-golang v1.0.199/go.mod h1:stZX+EPgv1vF4nZwOlEe8iGcriUPRBKX8zA19gXycOQ=
 github.com/volcengine/volcengine-go-sdk v1.2.9 h1:du2gnImtyWXKkQFnJW/GXCs+UBibGGOXIbP1Ams2pB8=
 github.com/volcengine/volcengine-go-sdk v1.2.9/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.2.27/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=

--- a/quickstart/chatwitheino/go.sum
+++ b/quickstart/chatwitheino/go.sum
@@ -110,9 +110,8 @@ github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5P
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.18 h1:xBd6wReRd8a4kcICvtVAaDZywMQ5Yw+ip+xCitm7y30=
-github.com/cloudwego/eino v0.9.0-alpha.18/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
-github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-alpha.24 h1:iUTgAHYARvR3N10PvxJxo9hkhshdmgP0kw4Itj2Lsbw=
+github.com/cloudwego/eino v0.9.0-alpha.24/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/adk/backend/local v0.2.2 h1:IWuzl4uZf4IkMN98ieRe9Ajl9E8L90twJh7gFBPXOrQ=
 github.com/cloudwego/eino-ext/adk/backend/local v0.2.2/go.mod h1:os5Tq5FuSoz/MLqAdZER3ip49Oef9prc0kVsKsPYO48=
 github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0 h1:KZ4HuOG/7xbx4bifxUL4zADTkeGwZ4vhqfUsIlFn12c=
@@ -541,8 +540,7 @@ github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
 github.com/volcengine/volc-sdk-golang v1.0.199 h1:zv9QOqTl/IsLwtfC37GlJtcz6vMAHi+pjq8ILWjLYUc=
 github.com/volcengine/volc-sdk-golang v1.0.199/go.mod h1:stZX+EPgv1vF4nZwOlEe8iGcriUPRBKX8zA19gXycOQ=
-github.com/volcengine/volcengine-go-sdk v1.2.9 h1:du2gnImtyWXKkQFnJW/GXCs+UBibGGOXIbP1Ams2pB8=
-github.com/volcengine/volcengine-go-sdk v1.2.9/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.2.27 h1:azBueeKhhGQukss+ob6m3oJ5K8GGYbfDNj8RKAEXVTE=
 github.com/volcengine/volcengine-go-sdk v1.2.27/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=

--- a/quickstart/eino_assistant/go.mod
+++ b/quickstart/eino_assistant/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/cloudwego/eino v0.9.0-alpha.18
+	github.com/cloudwego/eino v0.9.0-alpha.24
 	github.com/cloudwego/eino-ext/callbacks/apmplus v0.0.1
 	github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0
 	github.com/cloudwego/eino-ext/callbacks/langfuse v0.0.0-20250117061805-cd80d1780d76

--- a/quickstart/eino_assistant/go.sum
+++ b/quickstart/eino_assistant/go.sum
@@ -42,8 +42,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.18 h1:xBd6wReRd8a4kcICvtVAaDZywMQ5Yw+ip+xCitm7y30=
-github.com/cloudwego/eino v0.9.0-alpha.18/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-alpha.24 h1:iUTgAHYARvR3N10PvxJxo9hkhshdmgP0kw4Itj2Lsbw=
+github.com/cloudwego/eino v0.9.0-alpha.24/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/callbacks/apmplus v0.0.1 h1:aP9vfE61IBQXTjTiHf4gHUJ0QlgmVYlvZgmvxgVFkE8=
 github.com/cloudwego/eino-ext/callbacks/apmplus v0.0.1/go.mod h1:9WpHGYt5Ix2TeiTkY5oRzgt+d11KovNp73tufD5C9Ac=
 github.com/cloudwego/eino-ext/callbacks/cozeloop v0.2.0 h1:KZ4HuOG/7xbx4bifxUL4zADTkeGwZ4vhqfUsIlFn12c=


### PR DESCRIPTION
## Summary

| What | Why |
|------|-----|
| Add `adk/cancel/graceful-exit` example | Demonstrate the new Agent Cancel + Resume capability introduced in eino v0.9.0 |

## Key Insight

A single-round agent (no tools) finishes entirely within one ChatModel call. When `CancelAfterChatModel` fires, the agent is already done — leaving nothing to resume. This example deliberately uses **3 mock tools** (`search_web → analyze_data → summarize_findings`) to create multiple ChatModel rounds, making the cancel/resume lifecycle observable and meaningful.

## What Changed

**New file: `adk/cancel/graceful-exit/main.go`**

A self-contained example demonstrating:

1. **Phase 1 — Run + Cancel**: An agent configured with tools starts a multi-step research task. A goroutine listens for `SIGINT`/`SIGTERM`. On Ctrl-C, it calls the cancel function with `CancelAfterChatModel` mode and a 30s timeout. The cancel waits for the current ChatModel call to finish (the graceful safe-point), then saves a checkpoint.

2. **Phase 2 — Resume**: A new Runner resumes from the checkpoint. The agent picks up from wherever it was interrupted in the tool workflow and completes.

**Console UX**: ANSI-colored output distinguishes system messages (yellow/green/red) from model output (cyan), with box-drawing phase headers and dimmed tool call traces.

**APIs demonstrated**: `WithCancel`, `WithCheckPointID`, `WithAgentCancelMode`, `WithAgentCancelTimeout`, `CancelError`, `Runner.Resume`.

**go.mod/go.sum**: bumped `github.com/cloudwego/eino` from `v0.9.0-alpha.22` to `v0.9.0-alpha.24` (needed for `components/tool/utils` import).

---

## 概要

| 变更 | 原因 |
|------|------|
| 新增 `adk/cancel/graceful-exit` 示例 | 演示 eino v0.9.0 引入的 Agent Cancel + Resume 能力 |

## 核心洞察

无工具的单轮 Agent 在一次 ChatModel 调用内就跑完了。`CancelAfterChatModel` 触发时 Agent 已经结束，Resume 无事可做。本示例特意使用 **3 个 mock 工具**（`search_web → analyze_data → summarize_findings`）制造多轮 ChatModel 调用，让 cancel/resume 生命周期可观测、有意义。

## 变更内容

**新文件：`adk/cancel/graceful-exit/main.go`**

自包含示例，演示：

1. **阶段一 — 运行 + 取消**：带工具的 Agent 开始多步研究任务。一个 goroutine 监听 `SIGINT`/`SIGTERM`。按下 Ctrl-C 后，以 `CancelAfterChatModel` 模式 + 30s 超时调用 cancel 函数。Cancel 等待当前 ChatModel 调用完成（安全点），然后保存 checkpoint。

2. **阶段二 — 恢复**：新的 Runner 从 checkpoint 恢复。Agent 从中断点继续执行剩余工具调用并完成任务。

**控制台体验**：ANSI 彩色输出区分系统消息（黄/绿/红）和模型输出（青），带 box-drawing 阶段标题和暗色工具调用追踪。

**演示的 API**：`WithCancel`、`WithCheckPointID`、`WithAgentCancelMode`、`WithAgentCancelTimeout`、`CancelError`、`Runner.Resume`。

**go.mod/go.sum**：`github.com/cloudwego/eino` 从 `v0.9.0-alpha.22` 升级到 `v0.9.0-alpha.24`（`components/tool/utils` 导入需要）。
